### PR TITLE
Add possibility to use dummy audio for testing purposes

### DIFF
--- a/webrtc-jni/src/main/cpp/include/JNI_AudioDeviceModule.h
+++ b/webrtc-jni/src/main/cpp/include/JNI_AudioDeviceModule.h
@@ -149,7 +149,7 @@ extern "C" {
 	 * Signature: ()V
 	 */
 	JNIEXPORT void JNICALL Java_dev_onvoid_webrtc_media_audio_AudioDeviceModule_initialize
-	(JNIEnv *, jobject);
+	(JNIEnv *, jobject, jobject);
 
 #ifdef __cplusplus
 }

--- a/webrtc-jni/src/main/cpp/src/JNI_AudioDeviceModule.cpp
+++ b/webrtc-jni/src/main/cpp/src/JNI_AudioDeviceModule.cpp
@@ -17,6 +17,7 @@
 #include "JNI_AudioDeviceModule.h"
 #include "Exception.h"
 #include "JavaArrayList.h"
+#include "JavaEnums.h"
 #include "JavaError.h"
 #include "JavaObject.h"
 #include "JavaRef.h"
@@ -305,7 +306,7 @@ JNIEXPORT void JNICALL Java_dev_onvoid_webrtc_media_audio_AudioDeviceModule_disp
 }
 
 JNIEXPORT void JNICALL Java_dev_onvoid_webrtc_media_audio_AudioDeviceModule_initialize
-(JNIEnv * env, jobject caller)
+(JNIEnv * env, jobject caller, jobject jAudioLayer)
 {
 	std::unique_ptr<webrtc::TaskQueueFactory> taskQueueFactory = webrtc::CreateDefaultTaskQueueFactory();
 
@@ -314,8 +315,10 @@ JNIEXPORT void JNICALL Java_dev_onvoid_webrtc_media_audio_AudioDeviceModule_init
 		return;
 	}
 
+	const auto audioLayer = jni::JavaEnums::toNative<webrtc::AudioDeviceModule::AudioLayer>(env, jAudioLayer);
+
 	rtc::scoped_refptr<webrtc::AudioDeviceModule> audioModule = webrtc::AudioDeviceModule::Create(
-		webrtc::AudioDeviceModule::kPlatformDefaultAudio, taskQueueFactory.release());
+		audioLayer, taskQueueFactory.release());
 
 	if (!audioModule) {
 		env->Throw(jni::JavaError(env, "Create AudioDeviceModule failed"));

--- a/webrtc-jni/src/main/cpp/src/WebRTCContext.cpp
+++ b/webrtc-jni/src/main/cpp/src/WebRTCContext.cpp
@@ -79,6 +79,7 @@ namespace jni
 		JavaEnums::add<webrtc::PeerConnectionInterface::TlsCertPolicy>(env, PKG"TlsCertPolicy");
 		JavaEnums::add<webrtc::RtpTransceiverDirection>(env, PKG"RTCRtpTransceiverDirection");
 		JavaEnums::add<webrtc::SdpType>(env, PKG"RTCSdpType");
+		JavaEnums::add<webrtc::AudioDeviceModule::AudioLayer>(env, PKG_AUDIO"AudioLayer");
 		JavaEnums::add<jni::RTCStats::RTCStatsType>(env, PKG"RTCStatsType");
 
 		JavaFactories::add<webrtc::AudioSourceInterface>(env, PKG_MEDIA"audio/AudioSource");

--- a/webrtc/src/main/java/dev/onvoid/webrtc/media/audio/AudioDeviceModule.java
+++ b/webrtc/src/main/java/dev/onvoid/webrtc/media/audio/AudioDeviceModule.java
@@ -21,7 +21,11 @@ import dev.onvoid.webrtc.internal.DisposableNativeObject;
 public class AudioDeviceModule extends DisposableNativeObject {
 
 	public AudioDeviceModule() {
-		initialize();
+		initialize(AudioLayer.kPlatformDefaultAudio);
+	}
+
+	public AudioDeviceModule(AudioLayer audioLayer) {
+		initialize(audioLayer);
 	}
 
 	public native void initPlayout();
@@ -59,6 +63,6 @@ public class AudioDeviceModule extends DisposableNativeObject {
 	@Override
 	public native void dispose();
 
-	private native void initialize();
+	private native void initialize(AudioLayer audioLayer);
 
 }

--- a/webrtc/src/main/java/dev/onvoid/webrtc/media/audio/AudioLayer.java
+++ b/webrtc/src/main/java/dev/onvoid/webrtc/media/audio/AudioLayer.java
@@ -1,0 +1,15 @@
+package dev.onvoid.webrtc.media.audio;
+
+public enum AudioLayer {
+	kPlatformDefaultAudio,
+	kWindowsCoreAudio,
+	kWindowsCoreAudio2,
+	kLinuxAlsaAudio,
+	kLinuxPulseAudio,
+	kAndroidJavaAudio,
+	kAndroidOpenSLESAudio,
+	kAndroidJavaInputAndOpenSLESOutputAudio,
+	kAndroidAAudioAudio,
+	kAndroidJavaInputAndAAudioOutputAudio,
+	kDummyAudio
+}

--- a/webrtc/src/test/java/dev/onvoid/webrtc/DummyAudioDeviceModuleTest.java
+++ b/webrtc/src/test/java/dev/onvoid/webrtc/DummyAudioDeviceModuleTest.java
@@ -1,0 +1,39 @@
+package dev.onvoid.webrtc;
+
+import dev.onvoid.webrtc.media.audio.AudioDeviceModule;
+import dev.onvoid.webrtc.media.audio.AudioLayer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Execution(ExecutionMode.SAME_THREAD)
+public class DummyAudioDeviceModuleTest {
+	private PeerConnectionFactory factory;
+
+	@BeforeAll
+	void initFactory() {
+		factory = new PeerConnectionFactory(new AudioDeviceModule());
+	}
+
+	@AfterAll
+	void disposeFactory() {
+		factory.dispose();
+	}
+
+	@Test
+	void createPeerConnectionWithDummyAudio() {
+		RTCConfiguration config = new RTCConfiguration();
+		RTCPeerConnection peerConnection = factory.createPeerConnection(config,
+				candidate -> { });
+
+		assertNotNull(peerConnection);
+
+		peerConnection.close();
+	}
+}

--- a/webrtc/src/test/java/dev/onvoid/webrtc/DummyAudioDeviceModuleTest.java
+++ b/webrtc/src/test/java/dev/onvoid/webrtc/DummyAudioDeviceModuleTest.java
@@ -18,7 +18,7 @@ public class DummyAudioDeviceModuleTest {
 
 	@BeforeAll
 	void initFactory() {
-		factory = new PeerConnectionFactory(new AudioDeviceModule());
+		factory = new PeerConnectionFactory(new AudioDeviceModule(AudioLayer.kDummyAudio));
 	}
 
 	@AfterAll


### PR DESCRIPTION
Add the `AudioLayer` enum that allows using `kDummyAudio` when the library is used for testing purposes.