### PR TITLE
fix memory leak

### DIFF
--- a/webrtc-jni/pom.xml
+++ b/webrtc-jni/pom.xml
@@ -12,7 +12,7 @@
 	<packaging>pom</packaging>
 
 	<properties>
-		<webrtc.branch>branch-heads/4844</webrtc.branch>
+		<webrtc.branch>branch-heads/5268</webrtc.branch>
 		<webrtc.src.dir>${user.home}/webrtc</webrtc.src.dir>
 		<webrtc.install.dir>${user.home}/webrtc/build</webrtc.install.dir>
 		<cmake.build.type>Release</cmake.build.type>

--- a/webrtc-jni/pom.xml
+++ b/webrtc-jni/pom.xml
@@ -12,7 +12,7 @@
 	<packaging>pom</packaging>
 
 	<properties>
-		<webrtc.branch>branch-heads/5281</webrtc.branch>
+		<webrtc.branch>branch-heads/4844</webrtc.branch>
 		<webrtc.src.dir>${user.home}/webrtc</webrtc.src.dir>
 		<webrtc.install.dir>${user.home}/webrtc/build</webrtc.install.dir>
 		<cmake.build.type>Release</cmake.build.type>

--- a/webrtc-jni/pom.xml
+++ b/webrtc-jni/pom.xml
@@ -12,7 +12,7 @@
 	<packaging>pom</packaging>
 
 	<properties>
-		<webrtc.branch>branch-heads/5268</webrtc.branch>
+		<webrtc.branch>branch-heads/5281</webrtc.branch>
 		<webrtc.src.dir>${user.home}/webrtc</webrtc.src.dir>
 		<webrtc.install.dir>${user.home}/webrtc/build</webrtc.install.dir>
 		<cmake.build.type>Release</cmake.build.type>

--- a/webrtc-jni/src/main/cpp/src/api/AudioTrackSink.cpp
+++ b/webrtc-jni/src/main/cpp/src/api/AudioTrackSink.cpp
@@ -37,6 +37,7 @@ namespace jni
 		env->SetByteArrayRegion(dataArray, 0, dataSize, buffer);
 
 		env->CallVoidMethod(sink, javaClass->onData, dataArray, bitsPerSample, sampleRate, channels, frames);
+		env->DeleteLocalRef(dataArray);
 	}
 
 	AudioTrackSink::JavaAudioTrackSinkClass::JavaAudioTrackSinkClass(JNIEnv * env)

--- a/webrtc-jni/src/main/cpp/src/api/VideoFrame.cpp
+++ b/webrtc-jni/src/main/cpp/src/api/VideoFrame.cpp
@@ -56,7 +56,9 @@ namespace jni
 				yBuffer, buffer->StrideY(), uBuffer, buffer->StrideU(), vBuffer, buffer->StrideV());
 
 			SetHandle(env, jBuffer, buffer.get());
-
+			env->DeleteLocalRef(yBuffer);
+			env->DeleteLocalRef(uBuffer);
+			env->DeleteLocalRef(vBuffer);
 			return JavaLocalRef<jobject>(env, jBuffer);
 		}
 	}

--- a/webrtc-jni/src/main/cpp/src/api/VideoTrackSink.cpp
+++ b/webrtc-jni/src/main/cpp/src/api/VideoTrackSink.cpp
@@ -49,7 +49,6 @@ namespace jni
 		jobject jFrame = env->NewObject(javaFrameClass->cls, javaFrameClass->ctor, jBuffer.get(), rotation, timestamp);
 
 		env->CallVoidMethod(sink, javaClass->onFrame, jFrame);
-		env->DeleteLocalRef(jFrame);
 	}
 
 	VideoTrackSink::JavaVideoTrackSinkClass::JavaVideoTrackSinkClass(JNIEnv * env)

--- a/webrtc-jni/src/main/cpp/src/api/VideoTrackSink.cpp
+++ b/webrtc-jni/src/main/cpp/src/api/VideoTrackSink.cpp
@@ -49,6 +49,7 @@ namespace jni
 		jobject jFrame = env->NewObject(javaFrameClass->cls, javaFrameClass->ctor, jBuffer.get(), rotation, timestamp);
 
 		env->CallVoidMethod(sink, javaClass->onFrame, jFrame);
+		env->DeleteLocalRef(jFrame);
 	}
 
 	VideoTrackSink::JavaVideoTrackSinkClass::JavaVideoTrackSinkClass(JNIEnv * env)

--- a/webrtc-jni/src/main/cpp/src/api/VideoTrackSink.cpp
+++ b/webrtc-jni/src/main/cpp/src/api/VideoTrackSink.cpp
@@ -38,9 +38,9 @@ namespace jni
 		rtc::scoped_refptr<webrtc::VideoFrameBuffer> buffer = frame.video_frame_buffer();
 		rtc::scoped_refptr<webrtc::I420BufferInterface> i420Buffer = buffer->ToI420();
 
-		if (frame.rotation() != webrtc::kVideoRotation_0) {
-			i420Buffer = webrtc::I420Buffer::Rotate(*i420Buffer, frame.rotation());
-		}
+//		if (frame.rotation() != webrtc::kVideoRotation_0) {
+//			i420Buffer = webrtc::I420Buffer::Rotate(*i420Buffer, frame.rotation());
+//		}
 
 		jint rotation = static_cast<jint>(frame.rotation());
 		jlong timestamp = frame.timestamp_us() * rtc::kNumNanosecsPerMicrosec;

--- a/webrtc-jni/src/main/cpp/src/api/VideoTrackSink.cpp
+++ b/webrtc-jni/src/main/cpp/src/api/VideoTrackSink.cpp
@@ -49,6 +49,8 @@ namespace jni
 		jobject jFrame = env->NewObject(javaFrameClass->cls, javaFrameClass->ctor, jBuffer.get(), rotation, timestamp);
 
 		env->CallVoidMethod(sink, javaClass->onFrame, jFrame);
+		env->DeleteLocalRef(jBuffer);
+		env->DeleteLocalRef(jFrame);
 	}
 
 	VideoTrackSink::JavaVideoTrackSinkClass::JavaVideoTrackSinkClass(JNIEnv * env)


### PR DESCRIPTION
While profiling my application, i noticed some memory leaks
1. 960 byte arrays, which was same length passed into AudioSink, fixed in AudioTrackSink
2. some VideoFrame and NativeI420Buffer were not released, fixed in VideoTrackSink and VideoFrame

From these fixes, my application does not seem to have a memory leak, capable of running for hrs with only 100mb heap, compared to a few minutes before this patch. 
This is the first time I'm doing anything related to JNI, would like feedback on how viable my solutions are.