### PR TITLE
Crash after java callback if exception occurred

### DIFF
--- a/webrtc-jni/src/main/cpp/dependencies/jni-voithos/src/JavaHashMap.cpp
+++ b/webrtc-jni/src/main/cpp/dependencies/jni-voithos/src/JavaHashMap.cpp
@@ -34,6 +34,7 @@ namespace jni
 	void JavaHashMap::put(const JavaRef<jobject> & key, const JavaRef<jobject> & value)
 	{
 		env->CallVoidMethod(jMap, mapClass->put, key.get(), value.get());
+		ExceptionCheck(env);
 	}
 
 	JavaMapIterator JavaHashMap::begin()

--- a/webrtc-jni/src/main/cpp/dependencies/jni-voithos/src/JavaUtils.cpp
+++ b/webrtc-jni/src/main/cpp/dependencies/jni-voithos/src/JavaUtils.cpp
@@ -22,6 +22,7 @@ bool ExceptionCheck(JNIEnv * env)
 {
 	if (env->ExceptionCheck()) {
 		jthrowable exception = env->ExceptionOccurred();
+		env->ExceptionDescribe();
 		env->ExceptionClear();
 
 		if (exception) {
@@ -123,7 +124,7 @@ jfieldID GetFieldID(JNIEnv * env, jobject obj, const std::string & fieldName, co
 jfieldID GetFieldID(JNIEnv * env, jclass cls, const std::string & fieldName, const char * type)
 {
 	jfieldID field = env->GetFieldID(cls, fieldName.c_str(), type);
-	
+
 	if (field == nullptr) {
 		ExceptionCheck(env);
 		return nullptr;

--- a/webrtc-jni/src/main/cpp/src/JNI_AudioDeviceModule.cpp
+++ b/webrtc-jni/src/main/cpp/src/JNI_AudioDeviceModule.cpp
@@ -199,7 +199,7 @@ JNIEXPORT void JNICALL Java_dev_onvoid_webrtc_media_audio_AudioDeviceModule_setR
 	}
 
 	jni::JavaObject obj(env, jni::JavaLocalRef<jobject>(env, device));
-	
+
 	const auto javaClass = jni::JavaClasses::get<jni::AudioDevice::JavaAudioDeviceClass>(env);
 	const std::string devGuid = jni::JavaString::toNative(env, obj.getString(javaClass->descriptor));
 

--- a/webrtc-jni/src/main/cpp/src/api/AudioTrackSink.cpp
+++ b/webrtc-jni/src/main/cpp/src/api/AudioTrackSink.cpp
@@ -37,6 +37,7 @@ namespace jni
 		env->SetByteArrayRegion(dataArray, 0, dataSize, buffer);
 
 		env->CallVoidMethod(sink, javaClass->onData, dataArray, bitsPerSample, sampleRate, channels, frames);
+		ExceptionCheck(env);
 		env->DeleteLocalRef(dataArray);
 	}
 

--- a/webrtc-jni/src/main/cpp/src/api/CreateSessionDescriptionObserver.cpp
+++ b/webrtc-jni/src/main/cpp/src/api/CreateSessionDescriptionObserver.cpp
@@ -35,6 +35,8 @@ namespace jni
 		JavaLocalRef<jobject> javaDesc = jni::RTCSessionDescription::toJava(env, desc);
 
 		env->CallVoidMethod(observer, javaClass->onSuccess, javaDesc.get());
+
+		ExceptionCheck(env);
 	}
 
 	void CreateSessionDescriptionObserver::OnFailure(webrtc::RTCError error)
@@ -44,6 +46,8 @@ namespace jni
 		JavaLocalRef<jstring> errorMessage = JavaString::toJava(env, RTCErrorToString(error));
 
 		env->CallVoidMethod(observer, javaClass->onFailure, errorMessage.get());
+
+ 		ExceptionCheck(env);
 	}
 
 	CreateSessionDescriptionObserver::JavaCreateSessionDescObserverClass::JavaCreateSessionDescObserverClass(JNIEnv * env)

--- a/webrtc-jni/src/main/cpp/src/api/PeerConnectionObserver.cpp
+++ b/webrtc-jni/src/main/cpp/src/api/PeerConnectionObserver.cpp
@@ -42,6 +42,8 @@ namespace jni
 		auto jState = JavaEnums::toJava(env, state);
 
 		env->CallVoidMethod(observer, javaClass->onConnectionChange, jState.get());
+
+		ExceptionCheck(env);
 	}
 
 	void PeerConnectionObserver::OnSignalingChange(webrtc::PeerConnectionInterface::SignalingState state)
@@ -51,6 +53,8 @@ namespace jni
 		auto jState = JavaEnums::toJava(env, state);
 
 		env->CallVoidMethod(observer, javaClass->onSignalingChange, jState.get());
+
+		ExceptionCheck(env);
 	}
 
 	void PeerConnectionObserver::OnTrack(rtc::scoped_refptr<webrtc::RtpTransceiverInterface> transceiver)
@@ -60,6 +64,8 @@ namespace jni
 		auto jTransceiver = JavaFactories::create(env, transceiver.get());
 
 		env->CallVoidMethod(observer, javaClass->onTrack, jTransceiver.get());
+
+		ExceptionCheck(env);
 	}
 
 	void PeerConnectionObserver::OnAddTrack(rtc::scoped_refptr<webrtc::RtpReceiverInterface> receiver, const std::vector<rtc::scoped_refptr<webrtc::MediaStreamInterface>> & streams)
@@ -78,6 +84,8 @@ namespace jni
 		catch (...) {
 			ThrowCxxJavaException(env);
 		}
+
+		ExceptionCheck(env);
 	}
 
 	void PeerConnectionObserver::OnRemoveTrack(rtc::scoped_refptr<webrtc::RtpReceiverInterface> receiver)
@@ -87,6 +95,8 @@ namespace jni
 		auto jReceiver = JavaFactories::create(env, receiver.get());
 
 		env->CallVoidMethod(observer, javaClass->onRemoveTrack, jReceiver.get());
+
+		ExceptionCheck(env);
 	}
 
 	void PeerConnectionObserver::OnDataChannel(rtc::scoped_refptr<webrtc::DataChannelInterface> channel)
@@ -96,6 +106,8 @@ namespace jni
 		auto jDataChannel = JavaFactories::create(env, channel.release());
 
 		env->CallVoidMethod(observer, javaClass->onDataChannel, jDataChannel.get());
+
+		ExceptionCheck(env);
 	}
 
 	void PeerConnectionObserver::OnRenegotiationNeeded()
@@ -103,6 +115,8 @@ namespace jni
 		JNIEnv * env = AttachCurrentThread();
 
 		env->CallVoidMethod(observer, javaClass->onRenegotiationNeeded);
+
+		ExceptionCheck(env);
 	}
 
 	void PeerConnectionObserver::OnIceConnectionChange(webrtc::PeerConnectionInterface::IceConnectionState state)
@@ -112,6 +126,8 @@ namespace jni
 		auto jState = JavaEnums::toJava(env, state);
 
 		env->CallVoidMethod(observer, javaClass->onIceConnectionChange, jState.get());
+
+		ExceptionCheck(env);
 	}
 
 	void PeerConnectionObserver::OnIceGatheringChange(webrtc::PeerConnectionInterface::IceGatheringState state)
@@ -121,6 +137,8 @@ namespace jni
 		auto jState = JavaEnums::toJava(env, state);
 
 		env->CallVoidMethod(observer, javaClass->onIceGatheringChange, jState.get());
+
+		ExceptionCheck(env);
 	}
 
 	void PeerConnectionObserver::OnIceCandidate(const webrtc::IceCandidateInterface * candidate)
@@ -130,6 +148,8 @@ namespace jni
 		JavaLocalRef<jobject> jCandidate = RTCIceCandidate::toJava(env, candidate);
 
 		env->CallVoidMethod(observer, javaClass->onIceCandidate, jCandidate.get());
+
+		ExceptionCheck(env);
 	}
 
 	void PeerConnectionObserver::OnIceCandidateError(const std::string & address, int port, const std::string & url, int error_code, const std::string & error_text)
@@ -139,8 +159,10 @@ namespace jni
 		JavaLocalRef<jobject> event = RTCPeerConnectionIceErrorEvent::toJava(env, address, port, url, error_code, error_text);
 
 		env->CallVoidMethod(observer, javaClass->onIceCandidateError, event.get());
+
+		ExceptionCheck(env);
 	}
-	
+
 	void PeerConnectionObserver::OnIceCandidatesRemoved(const std::vector<cricket::Candidate> & candidates)
 	{
 		JNIEnv * env = AttachCurrentThread();
@@ -158,6 +180,8 @@ namespace jni
 		catch (...) {
 			ThrowCxxJavaException(env);
 		}
+
+		ExceptionCheck(env);
 	}
 
 	void PeerConnectionObserver::OnIceConnectionReceivingChange(bool receiving)
@@ -165,6 +189,8 @@ namespace jni
 		JNIEnv * env = AttachCurrentThread();
 
 		env->CallVoidMethod(observer, javaClass->onIceConnectionReceivingChange, receiving);
+
+		ExceptionCheck(env);
 	}
 
 	PeerConnectionObserver::JavaPeerConnectionObserverClass::JavaPeerConnectionObserverClass(JNIEnv * env)

--- a/webrtc-jni/src/main/cpp/src/api/RTCDataChannelObserver.cpp
+++ b/webrtc-jni/src/main/cpp/src/api/RTCDataChannelObserver.cpp
@@ -33,6 +33,8 @@ namespace jni
 		JNIEnv * env = AttachCurrentThread();
 
 		env->CallVoidMethod(observer, javaClass->onStateChange);
+
+		ExceptionCheck(env);
 	}
 
 	void RTCDataChannelObserver::OnMessage(const webrtc::DataBuffer & buffer)
@@ -42,6 +44,8 @@ namespace jni
 		JavaLocalRef<jobject> jBuffer = bufferFactory->create(env, &buffer);
 
 		env->CallVoidMethod(observer, javaClass->onMessage, jBuffer.release());
+
+		ExceptionCheck(env);
 	}
 
 	RTCDataChannelObserver::JavaRTCDataChannelObserverClass::JavaRTCDataChannelObserverClass(JNIEnv * env)

--- a/webrtc-jni/src/main/cpp/src/api/RTCDtlsTransportObserver.cpp
+++ b/webrtc-jni/src/main/cpp/src/api/RTCDtlsTransportObserver.cpp
@@ -33,10 +33,12 @@ namespace jni
 	void RTCDtlsTransportObserver::OnStateChange(webrtc::DtlsTransportInformation info)
 	{
 		JNIEnv * env = AttachCurrentThread();
-		
+
 		auto state = JavaEnums::toJava(env, info.state());
 
 		env->CallVoidMethod(observer, javaClass->onStateChange, state.get());
+
+		ExceptionCheck(env);
 	}
 
 	void RTCDtlsTransportObserver::OnError(webrtc::RTCError error)
@@ -46,6 +48,8 @@ namespace jni
 		JavaLocalRef<jstring> errorMessage = JavaString::toJava(env, RTCErrorToString(error));
 
 		env->CallVoidMethod(observer, javaClass->onError, errorMessage.get());
+
+		ExceptionCheck(env);
 	}
 
 	RTCDtlsTransportObserver::JavaRTCDtlsTransportObserverClass::JavaRTCDtlsTransportObserverClass(JNIEnv * env)

--- a/webrtc-jni/src/main/cpp/src/api/RTCRtpCodecCapability.cpp
+++ b/webrtc-jni/src/main/cpp/src/api/RTCRtpCodecCapability.cpp
@@ -61,12 +61,12 @@ namespace jni
 			JavaObject obj(env, capability);
 
 			webrtc::RtpCodecCapability codecCapability;
-			
+
 			codecCapability.kind = JavaEnums::toNative<cricket::MediaType>(env, obj.getObject(javaClass->mediaType));
 			codecCapability.name = JavaString::toNative(env, obj.getString(javaClass->name));
 			codecCapability.clock_rate = obj.getInt<int>(javaClass->clockRate);
 			codecCapability.num_channels = obj.getInt<int>(javaClass->channels);
-			
+
 			for (const auto & entry : JavaHashMap(env, obj.getObject(javaClass->sdpFmtp))) {
 				std::string key = JavaString::toNative(env, static_java_ref_cast<jstring>(env, entry.first));
 				std::string value = JavaString::toNative(env, static_java_ref_cast<jstring>(env, entry.second));

--- a/webrtc-jni/src/main/cpp/src/api/RTCRtpEncodingParameters.cpp
+++ b/webrtc-jni/src/main/cpp/src/api/RTCRtpEncodingParameters.cpp
@@ -51,7 +51,7 @@ namespace jni
 
 			return JavaLocalRef<jobject>(env, object);
 		}
-		
+
 		webrtc::RtpEncodingParameters toNative(JNIEnv * env, const JavaRef<jobject> & parameters)
 		{
 			const auto javaClass = JavaClasses::get<JavaRTCRtpEncodingParametersClass>(env);
@@ -94,7 +94,7 @@ namespace jni
 			cls = FindClass(env, PKG"RTCRtpEncodingParameters");
 
 			ctor = GetMethod(env, cls, "<init>", "()V");
-			
+
 			ssrc = GetFieldID(env, cls, "ssrc", LONG_SIG);
 			active = GetFieldID(env, cls, "active", BOOLEAN_SIG);
 			minBitrate = GetFieldID(env, cls, "minBitrate", INTEGER_SIG);

--- a/webrtc-jni/src/main/cpp/src/api/RTCSessionDescription.cpp
+++ b/webrtc-jni/src/main/cpp/src/api/RTCSessionDescription.cpp
@@ -34,7 +34,7 @@ namespace jni
 
 			std::string sdpStr;
 			nativeType->ToString(&sdpStr);
-			
+
 			JavaLocalRef<jobject> type = JavaEnums::toJava(env, nativeType->GetType());
 			JavaLocalRef<jstring> sdp = JavaString::toJava(env, sdpStr);
 

--- a/webrtc-jni/src/main/cpp/src/api/RTCStatsCollectorCallback.cpp
+++ b/webrtc-jni/src/main/cpp/src/api/RTCStatsCollectorCallback.cpp
@@ -34,6 +34,8 @@ namespace jni
 		JavaLocalRef<jobject> javaReport = jni::RTCStatsReport::toJava(env, report);
 
 		env->CallVoidMethod(callback, javaClass->onStatsDelivered, javaReport.get());
+
+		ExceptionCheck(env);
 	}
 
 	RTCStatsCollectorCallback::JavaRTCStatsCollectorCallbackClass::JavaRTCStatsCollectorCallbackClass(JNIEnv * env)

--- a/webrtc-jni/src/main/cpp/src/api/SetSessionDescriptionObserver.cpp
+++ b/webrtc-jni/src/main/cpp/src/api/SetSessionDescriptionObserver.cpp
@@ -18,6 +18,7 @@
 #include "api/WebRTCUtils.h"
 #include "JavaString.h"
 #include "JNI_WebRTC.h"
+#include "JavaUtils.h"
 
 namespace jni
 {
@@ -32,6 +33,8 @@ namespace jni
 		JNIEnv * env = AttachCurrentThread();
 
 		env->CallVoidMethod(observer, javaClass->onSuccess);
+
+		ExceptionCheck(env);
 	}
 
 	void SetSessionDescriptionObserver::OnFailure(webrtc::RTCError error)
@@ -41,6 +44,8 @@ namespace jni
 		JavaLocalRef<jstring> errorMessage = JavaString::toJava(env, RTCErrorToString(error));
 
 		env->CallVoidMethod(observer, javaClass->onFailure, errorMessage.get());
+
+		ExceptionCheck(env);
 	}
 
 	SetSessionDescriptionObserver::JavaSetSessionDescObserverClass::JavaSetSessionDescObserverClass(JNIEnv * env)

--- a/webrtc-jni/src/main/cpp/src/api/VideoFrame.cpp
+++ b/webrtc-jni/src/main/cpp/src/api/VideoFrame.cpp
@@ -47,7 +47,7 @@ namespace jni
 		JavaLocalRef<jobject> toJava(JNIEnv * env, const rtc::scoped_refptr<webrtc::I420BufferInterface> & buffer)
 		{
 			const auto javaClass = JavaClasses::get<JavaNativeI420BufferClass>(env);
-			
+
 			jobject yBuffer = env->NewDirectByteBuffer(const_cast<uint8_t *>(buffer->DataY()), static_cast<jlong>(buffer->StrideY()) * buffer->height());
 			jobject uBuffer = env->NewDirectByteBuffer(const_cast<uint8_t *>(buffer->DataU()), static_cast<jlong>(buffer->StrideU()) * buffer->ChromaHeight());
 			jobject vBuffer = env->NewDirectByteBuffer(const_cast<uint8_t *>(buffer->DataV()), static_cast<jlong>(buffer->StrideV()) * buffer->ChromaHeight());

--- a/webrtc-jni/src/main/cpp/src/api/VideoTrackSink.cpp
+++ b/webrtc-jni/src/main/cpp/src/api/VideoTrackSink.cpp
@@ -34,7 +34,7 @@ namespace jni
 	void VideoTrackSink::OnFrame(const webrtc::VideoFrame & frame)
 	{
 		JNIEnv * env = AttachCurrentThread();
-		
+
 		rtc::scoped_refptr<webrtc::VideoFrameBuffer> buffer = frame.video_frame_buffer();
 		rtc::scoped_refptr<webrtc::I420BufferInterface> i420Buffer = buffer->ToI420();
 
@@ -44,11 +44,12 @@ namespace jni
 
 		jint rotation = static_cast<jint>(frame.rotation());
 		jlong timestamp = frame.timestamp_us() * rtc::kNumNanosecsPerMicrosec;
-		
+
 		JavaLocalRef<jobject> jBuffer = I420Buffer::toJava(env, i420Buffer);
 		jobject jFrame = env->NewObject(javaFrameClass->cls, javaFrameClass->ctor, jBuffer.get(), rotation, timestamp);
 
 		env->CallVoidMethod(sink, javaClass->onFrame, jFrame);
+		ExceptionCheck(env);
 		env->DeleteLocalRef(jBuffer);
 		env->DeleteLocalRef(jFrame);
 	}

--- a/webrtc-jni/src/main/cpp/src/media/MediaStreamTrackObserver.cpp
+++ b/webrtc-jni/src/main/cpp/src/media/MediaStreamTrackObserver.cpp
@@ -41,11 +41,13 @@ namespace jni
 			if (track->enabled() != trackEnabled) {
 				// The condition "muted" is managed using the "enabled" property.
 				env->CallVoidMethod(javaTrack, javaClass->onTrackMute, createJavaTrack(env).release(), !track->enabled());
+				ExceptionCheck(env);
 			}
 		}
 		else if (eventType == MediaStreamTrackEvent::ended) {
 			if (track->state() != trackState && track->state() == webrtc::MediaStreamTrackInterface::TrackState::kEnded) {
 				env->CallVoidMethod(javaTrack, javaClass->onTrackEnd, createJavaTrack(env).release());
+				ExceptionCheck(env);
 			}
 		}
 

--- a/webrtc-jni/src/main/cpp/src/media/audio/AudioTransportSink.cpp
+++ b/webrtc-jni/src/main/cpp/src/media/audio/AudioTransportSink.cpp
@@ -45,6 +45,8 @@ namespace jni
 		jbyteArray dataArray = env->NewByteArray(dataSize);
 		env->SetByteArrayRegion(dataArray, 0, dataSize, buffer);
 		env->CallVoidMethod(sink, javaClass->onRecordedData, dataArray, nSamples, nBytesPerSample, nChannels, samplesPerSec, totalDelayMS, clockDrift);
+
+		ExceptionCheck(env);
 		env->DeleteLocalRef(dataArray);
 
 		return 0;

--- a/webrtc-jni/src/main/cpp/src/media/video/desktop/DesktopCaptureCallback.cpp
+++ b/webrtc-jni/src/main/cpp/src/media/video/desktop/DesktopCaptureCallback.cpp
@@ -86,12 +86,12 @@ namespace jni
 			frame->stride() / webrtc::DesktopFrame::kBytesPerPixel, i420Buffer->height(), crop_w, crop_h,
 			libyuv::kRotate0,
 			libyuv::FOURCC_ARGB);
-		
+
 		if (conversionResult < 0) {
 			RTC_LOG(LS_ERROR) << "Failed to convert desktop frame to I420";
 			return;
 		}
-		
+
 		jint rotation = static_cast<jint>(webrtc::kVideoRotation_0);
 		jlong timestamp = rtc::TimeMicros() * rtc::kNumNanosecsPerMicrosec;
 
@@ -99,6 +99,8 @@ namespace jni
 		jobject jFrame = env->NewObject(javaFrameClass->cls, javaFrameClass->ctor, jBuffer.get(), rotation, timestamp);
 
 		env->CallVoidMethod(callback, javaClass->onCaptureResult, jresult.get(), jFrame);
+
+		ExceptionCheck(env);
 		env->DeleteLocalRef(jBuffer);
 		env->DeleteLocalRef(jFrame);
 	}

--- a/webrtc-jni/src/main/cpp/src/rtc/LogSink.cpp
+++ b/webrtc-jni/src/main/cpp/src/rtc/LogSink.cpp
@@ -39,6 +39,8 @@ namespace jni
 		JavaLocalRef<jstring> jMessage = JavaString::toJava(env, message);
 
 		env->CallVoidMethod(javaSink, javaClass->onLogMessage, jSeverity.get(), jMessage.get());
+
+		ExceptionCheck(env);
 	}
 
 	LogSink::JavaLogSinkClass::JavaLogSinkClass(JNIEnv * env)


### PR DESCRIPTION
When crap happens in a Java callback, crash immediately when control flow returns to JNI-land. Also be nice, name the exception and give location of crappy code.

How/Why I opened this PR:

I was playing with this library with the intention of opening a DataChannel between 2 peers, no Media tracks.

The behavior I observed most of the time was  that the DataChannel opened on the callee side and a crash happens on the caller side when the DataChannel "should have opened", after the PeerConnectionState reached the CONNECTED state.  The crashing side was not giving any hints but this:
```
terminate called after throwing an instance of 'jni::JavaWrappedException'
what():
```
No stacktrace/backtrace/core dump that I could find.
When it didn't crash, it strangely hanged in the connection process just after SDP offer/answer exchange.
Found https://github.com/devopvoid/webrtc-java/discussions/68 and https://github.com/devopvoid/webrtc-java/issues/37. Somewhat irrelevant.

Root Cause:
I had a faulty implementation of `onIceCandidate()` triggering a `NullPointerException`. NPE doesn't set the `what` field, so no error message. But since that callback is triggered from JNI-land (rather, a JNI-owned thread), the exception has to be manually checked with `ExceptionCheck()`, from what I understand.
Current implementation of `webrtc-java` doesn't have a lot of these checks.
After a while, I figured it only crashed when the JNI layer invoked `onDataChannel()` due to an `ExceptionCheck()` located there to check the instanciation of the Java DataChannel object in native code.

So in the end, it means that I had an exception happening fairly early in the connection process but crashed only at the end of the process due to a late, almost random, detection.

I'm therefore assuming it's not polite to return from Java-land without checking for exception and added a few checks on the callbacks I found. I may have missed some.
I'm also assuming the performance hit is negligible which may or may not be true.

Anyway, thank you @devopvoid for your work on this :) `mvn install` ran flawlessly on my end and enabled me to investigate my own mistake.