### PR TITLE
fix: made RTCRtpCodecCapability's int fields optional

### DIFF
--- a/webrtc/src/main/java/dev/onvoid/webrtc/RTCRtpCodecCapability.java
+++ b/webrtc/src/main/java/dev/onvoid/webrtc/RTCRtpCodecCapability.java
@@ -41,14 +41,14 @@ public class RTCRtpCodecCapability {
 	/**
 	 * The codec clock rate expressed in Hertz.
 	 */
-	private final int clockRate;
+	private final Integer clockRate;
 
 	/**
 	 * When present, indicates the number of audio channels (mono=1, stereo=2).
 	 * <p>
 	 * Unused for video codecs.
 	 */
-	private final int channels;
+	private final Integer channels;
 
 	/**
 	 * The "format specific parameters" from the "a=fmtp" line in the SDP
@@ -70,7 +70,7 @@ public class RTCRtpCodecCapability {
 	 * @param sdpFmtp   The "a=fmtp" parameters in the SDP.
 	 */
 	public RTCRtpCodecCapability(MediaType mediaType, String name,
-			int clockRate, int channels, Map<String, String> sdpFmtp) {
+			Integer clockRate, Integer channels, Map<String, String> sdpFmtp) {
 		this.mediaType = mediaType;
 		this.name = name;
 		this.clockRate = clockRate;

--- a/webrtc/src/test/java/dev/onvoid/webrtc/RTCRtpTransceiverTests.java
+++ b/webrtc/src/test/java/dev/onvoid/webrtc/RTCRtpTransceiverTests.java
@@ -55,7 +55,7 @@ class RTCRtpTransceiverTests extends TestBase {
 				new RTCRtpTransceiverInit());
 
 		audioTransceiver.setCodecPreferences(audioPreferences);
-//		videoTransceiver.setCodecPreferences(videoPreferences);
+		videoTransceiver.setCodecPreferences(videoPreferences);
 	}
 
 }


### PR DESCRIPTION
Hello! 👋

I tried to use `RTCRtpTransceiver.setCodecPreferences`, with codecs from `factory.getRtpSenderCapabilities(MediaType.VIDEO)`, but it failed with this message:
```
java.lang.Error: Set codec preferences failed: [INVALID_MODIFICATION] Invalid codec preferences: Missing codec from codec capabilities.
        at dev.onvoid.webrtc.RTCRtpTransceiver.setCodecPreferences(Native Method)
        at Rtc_main.<init>(rtc.main.kts:71)
```
This seems to be because `RTCRtpCodecCapability::toJava` and `RTCRtpCodecCapability::toNative` don't preserve the capability object because the java conversion uses `.value_or(0)` on the `std::optional<int>` fields `clock_rate` and `num_channels`.
(and then libwebrtc's `IsSameRtpCodec` [thinks the capability changed](https://webrtc.googlesource.com/src/+/refs/branch-heads/7204/media/base/codec_comparators.cc#367) and rejects it)

I converted the `int` fields to `Integer`, like `RTCRtpCodecParameters` does for the same reason, and uncommented a `setCodecPreferences` that was previously causing a test to fail.
The code pretty much matches with `RTCRtpCodecParameters.{java,cpp}`.

What do you think? :)