### PR TITLE
feat: add VideoBufferConverter.convertToI420

### DIFF
--- a/webrtc-jni/src/main/cpp/include/JNI_VideoBufferConverter.h
+++ b/webrtc-jni/src/main/cpp/include/JNI_VideoBufferConverter.h
@@ -23,6 +23,22 @@ extern "C" {
 	JNIEXPORT void JNICALL Java_dev_onvoid_webrtc_media_video_VideoBufferConverter_I420toDirectBuffer
 	(JNIEnv *, jclass, jobject, jint, jobject, jint, jobject, jint, jobject, jint, jint, jint);
 
+	/*
+	 * Class:     dev_onvoid_webrtc_media_video_VideoBufferConverter
+	 * Method:    byteArrayToI420
+	 * Signature: ([BIILjava/nio/ByteBuffer;ILjava/nio/ByteBuffer;ILjava/nio/ByteBuffer;II)V
+	 */
+	 JNIEXPORT void JNICALL Java_dev_onvoid_webrtc_media_video_VideoBufferConverter_byteArrayToI420
+	 (JNIEnv *, jclass, jbyteArray, jint, jint, jobject, jint, jobject, jint, jobject, jint, jint);
+
+	 /*
+	  * Class:     dev_onvoid_webrtc_media_video_VideoBufferConverter
+	  * Method:    directBufferToI420
+	  * Signature: (Ljava/nio/ByteBuffer;IILjava/nio/ByteBuffer;ILjava/nio/ByteBuffer;ILjava/nio/ByteBuffer;II)V
+	  */
+	 JNIEXPORT void JNICALL Java_dev_onvoid_webrtc_media_video_VideoBufferConverter_directBufferToI420
+	 (JNIEnv *, jclass, jobject, jint, jint, jobject, jint, jobject, jint, jobject, jint, jint);
+
 #ifdef __cplusplus
 }
 #endif

--- a/webrtc/src/main/java/dev/onvoid/webrtc/media/video/VideoBufferConverter.java
+++ b/webrtc/src/main/java/dev/onvoid/webrtc/media/video/VideoBufferConverter.java
@@ -48,6 +48,9 @@ public final class VideoBufferConverter {
 		if (dst == null) {
 			throw new NullPointerException("Destination buffer must not be null");
 		}
+		if (dst.isReadOnly()) {
+			throw new IllegalArgumentException("Destination buffer must not be read-only");
+		}
 		
 		I420Buffer i420 = src.toI420();
 		
@@ -81,6 +84,61 @@ public final class VideoBufferConverter {
 		}
 	}
 
+	public static void convertToI420(byte[] src, I420Buffer dst, FourCC fourCC) throws Exception {
+		if (src == null) {
+			throw new NullPointerException("Source buffer must not be null");
+		}
+		if (dst == null) {
+			throw new NullPointerException("Destination buffer must not be null");
+		}
+
+		byteArrayToI420(
+				src,
+				dst.getWidth(), dst.getHeight(),
+				dst.getDataY(), dst.getStrideY(),
+				dst.getDataU(), dst.getStrideU(),
+				dst.getDataV(), dst.getStrideV(),
+				fourCC.value());
+	}
+
+	public static void convertToI420(ByteBuffer src, I420Buffer dst, FourCC fourCC) throws Exception {
+		if (src == null) {
+			throw new NullPointerException("Source buffer must not be null");
+		}
+		if (dst == null) {
+			throw new NullPointerException("Destination buffer must not be null");
+		}
+
+		if (src.isDirect()) {
+			directBufferToI420(
+					src,
+					dst.getWidth(), dst.getHeight(),
+					dst.getDataY(), dst.getStrideY(),
+					dst.getDataU(), dst.getStrideU(),
+					dst.getDataV(), dst.getStrideV(),
+					fourCC.value());
+		}
+		else {
+			byte[] arrayBuffer;
+
+			if (src.hasArray()) {
+				arrayBuffer = src.array();
+			}
+			else {
+				arrayBuffer = new byte[src.remaining()];
+				src.get(arrayBuffer);
+			}
+
+			byteArrayToI420(
+					arrayBuffer,
+					dst.getWidth(), dst.getHeight(),
+					dst.getDataY(), dst.getStrideY(),
+					dst.getDataU(), dst.getStrideU(),
+					dst.getDataV(), dst.getStrideV(),
+					fourCC.value());
+		}
+	}
+
 	private native static void I420toByteArray(
 			ByteBuffer srcY, int srcStrideY,
 			ByteBuffer srcU, int srcStrideU,
@@ -95,6 +153,22 @@ public final class VideoBufferConverter {
 			ByteBuffer srcV, int srcStrideV,
 			ByteBuffer dst,
 			int width, int height,
+			int fourCC) throws Exception;
+
+	private native static void byteArrayToI420(
+			byte[] src,
+			int width, int height,
+			ByteBuffer dstY, int dstStrideY,
+			ByteBuffer dstU, int dstStrideU,
+			ByteBuffer dstV, int dstStrideV,
+			int fourCC) throws Exception;
+
+	private native static void directBufferToI420(
+			ByteBuffer src,
+			int width, int height,
+			ByteBuffer dstY, int dstStrideY,
+			ByteBuffer dstU, int dstStrideU,
+			ByteBuffer dstV, int dstStrideV,
 			int fourCC) throws Exception;
 
 }

--- a/webrtc/src/test/java/dev/onvoid/webrtc/media/video/VideoBufferConverterTest.java
+++ b/webrtc/src/test/java/dev/onvoid/webrtc/media/video/VideoBufferConverterTest.java
@@ -1,0 +1,347 @@
+/*
+ * Copyright 2025 Alex Andres
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.onvoid.webrtc.media.video;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.ByteBuffer;
+
+import dev.onvoid.webrtc.TestBase;
+import dev.onvoid.webrtc.media.FourCC;
+
+import org.junit.jupiter.api.Test;
+
+class VideoBufferConverterTest extends TestBase {
+
+	private static final int WIDTH = 32;
+	private static final int HEIGHT = 8;
+
+	@Test
+	void convertFromI420ToByteArray() throws Exception {
+		NativeI420Buffer i420 = NativeI420Buffer.allocate(WIDTH, HEIGHT);
+		initializeI420Buffer(i420);
+		byte[] rgba = new byte[4 * WIDTH * HEIGHT];
+		VideoBufferConverter.convertFromI420(i420, rgba, FourCC.RGBA);
+		verifyI420Buffer(i420, false);
+		verifyRGBAArray(rgba, true);
+	}
+
+	@Test
+	void convertFromI420ToDirectBuffer() throws Exception {
+		NativeI420Buffer i420 = NativeI420Buffer.allocate(WIDTH, HEIGHT);
+		initializeI420Buffer(i420);
+		ByteBuffer rgba = ByteBuffer.allocateDirect(4 * WIDTH * HEIGHT);
+		VideoBufferConverter.convertFromI420(i420, rgba, FourCC.RGBA);
+		verifyI420Buffer(i420, false);
+		verifyRGBABuffer(rgba, true);
+	}
+
+	@Test
+	void convertFromI420ToNonDirectBuffer() throws Exception {
+		NativeI420Buffer i420 = NativeI420Buffer.allocate(WIDTH, HEIGHT);
+		initializeI420Buffer(i420);
+		ByteBuffer rgba = ByteBuffer.allocate(4 * WIDTH * HEIGHT);
+		VideoBufferConverter.convertFromI420(i420, rgba, FourCC.RGBA);
+		verifyI420Buffer(i420, false);
+		verifyRGBABuffer(rgba, true);
+	}
+
+	@Test
+	void convertFromI420ToReadOnlyDirectBuffer() throws Exception {
+		NativeI420Buffer i420 = NativeI420Buffer.allocate(WIDTH, HEIGHT);
+		initializeI420Buffer(i420);
+		ByteBuffer rgba = ByteBuffer.allocateDirect(4 * WIDTH * HEIGHT);
+		assertThrows(IllegalArgumentException.class, () -> {
+			VideoBufferConverter.convertFromI420(i420, rgba.asReadOnlyBuffer(), FourCC.RGBA);
+		});
+	}
+
+	@Test
+	void convertFromI420ToReadOnlyNonDirectBuffer() throws Exception {
+		NativeI420Buffer i420 = NativeI420Buffer.allocate(WIDTH, HEIGHT);
+		initializeI420Buffer(i420);
+		ByteBuffer rgba = ByteBuffer.allocate(4 * WIDTH * HEIGHT);
+		assertThrows(IllegalArgumentException.class, () -> {
+			VideoBufferConverter.convertFromI420(i420, rgba.asReadOnlyBuffer(), FourCC.RGBA);
+		});
+	}
+
+	@Test
+	void convertFromI420ToSmallByteArray() throws Exception {
+		NativeI420Buffer i420 = NativeI420Buffer.allocate(WIDTH, HEIGHT);
+		initializeI420Buffer(i420);
+		byte[] rgba = new byte[4 * WIDTH * HEIGHT - 1];
+		assertThrows(RuntimeException.class, () -> {
+			VideoBufferConverter.convertFromI420(i420, rgba, FourCC.RGBA);
+		});
+	}
+
+	@Test
+	void convertFromI420ToSmallDirectBuffer() throws Exception {
+		NativeI420Buffer i420 = NativeI420Buffer.allocate(WIDTH, HEIGHT);
+		initializeI420Buffer(i420);
+		ByteBuffer rgba = ByteBuffer.allocateDirect(4 * WIDTH * HEIGHT - 1);
+		assertThrows(RuntimeException.class, () -> {
+			VideoBufferConverter.convertFromI420(i420, rgba, FourCC.RGBA);
+		});
+	}
+
+	@Test
+	void convertFromI420ToSmallNonDirectBuffer() throws Exception {
+		NativeI420Buffer i420 = NativeI420Buffer.allocate(WIDTH, HEIGHT);
+		initializeI420Buffer(i420);
+		ByteBuffer rgba = ByteBuffer.allocate(4 * WIDTH * HEIGHT - 1);
+		assertThrows(RuntimeException.class, () -> {
+			VideoBufferConverter.convertFromI420(i420, rgba, FourCC.RGBA);
+		});
+	}
+
+	@Test
+	void convertFromByteArrayToI420() throws Exception {
+		byte[] rgba = new byte[4 * WIDTH * HEIGHT];
+		initializeRGBAArray(rgba);
+		NativeI420Buffer i420 = NativeI420Buffer.allocate(WIDTH, HEIGHT);
+		VideoBufferConverter.convertToI420(rgba, i420, FourCC.RGBA);
+		verifyRGBAArray(rgba, false);
+		verifyI420Buffer(i420, true);
+	}
+
+	@Test
+	void convertFromDirectBufferToI420() throws Exception {
+		ByteBuffer rgba = ByteBuffer.allocateDirect(4 * WIDTH * HEIGHT);
+		initializeRGBABuffer(rgba);
+		rgba.rewind();
+		NativeI420Buffer i420 = NativeI420Buffer.allocate(WIDTH, HEIGHT);
+		VideoBufferConverter.convertToI420(rgba, i420, FourCC.RGBA);
+		verifyRGBABuffer(rgba, false);
+		verifyI420Buffer(i420, true);
+	}
+
+	@Test
+	void convertFromNonDirectBufferToI420() throws Exception {
+		ByteBuffer rgba = ByteBuffer.allocate(4 * WIDTH * HEIGHT);
+		initializeRGBABuffer(rgba);
+		rgba.rewind();
+		NativeI420Buffer i420 = NativeI420Buffer.allocate(WIDTH, HEIGHT);
+		VideoBufferConverter.convertToI420(rgba, i420, FourCC.RGBA);
+		verifyRGBABuffer(rgba, false);
+		verifyI420Buffer(i420, true);
+	}
+
+	@Test
+	void convertFromReadOnlyDirectBufferToI420() throws Exception {
+		ByteBuffer rgba = ByteBuffer.allocateDirect(4 * WIDTH * HEIGHT);
+		initializeRGBABuffer(rgba);
+		rgba.rewind();
+		NativeI420Buffer i420 = NativeI420Buffer.allocate(WIDTH, HEIGHT);
+		VideoBufferConverter.convertToI420(rgba.asReadOnlyBuffer(), i420, FourCC.RGBA);
+		verifyRGBABuffer(rgba, false);
+		verifyI420Buffer(i420, true);
+	}
+
+	@Test
+	void convertFromReadOnlyNonDirectBufferToI420() throws Exception {
+		ByteBuffer rgba = ByteBuffer.allocate(4 * WIDTH * HEIGHT);
+		initializeRGBABuffer(rgba);
+		rgba.rewind();
+		NativeI420Buffer i420 = NativeI420Buffer.allocate(WIDTH, HEIGHT);
+		VideoBufferConverter.convertToI420(rgba.asReadOnlyBuffer(), i420, FourCC.RGBA);
+		verifyRGBABuffer(rgba, false);
+		verifyI420Buffer(i420, true);
+	}
+
+	@Test
+	void convertFromSmallByteArrayToI420() throws Exception {
+		byte[] rgba = new byte[4 * WIDTH * HEIGHT - 1];
+		initializeRGBAArray(rgba);
+		NativeI420Buffer i420 = NativeI420Buffer.allocate(WIDTH, HEIGHT);
+		assertThrows(RuntimeException.class, () -> {
+			VideoBufferConverter.convertToI420(rgba, i420, FourCC.RGBA);
+		});
+	}
+
+	@Test
+	void convertFromSmallDirectBufferToI420() throws Exception {
+		ByteBuffer rgba = ByteBuffer.allocateDirect(4 * WIDTH * HEIGHT - 1);
+		initializeRGBABuffer(rgba);
+		rgba.rewind();
+		NativeI420Buffer i420 = NativeI420Buffer.allocate(WIDTH, HEIGHT);
+		assertThrows(RuntimeException.class, () -> {
+			VideoBufferConverter.convertToI420(rgba, i420, FourCC.RGBA);
+		});
+	}
+
+	@Test
+	void convertFromSmallNonDirectBufferToI420() throws Exception {
+		ByteBuffer rgba = ByteBuffer.allocate(4 * WIDTH * HEIGHT - 1);
+		initializeRGBABuffer(rgba);
+		rgba.rewind();
+		NativeI420Buffer i420 = NativeI420Buffer.allocate(WIDTH, HEIGHT);
+		assertThrows(RuntimeException.class, () -> {
+			VideoBufferConverter.convertToI420(rgba, i420, FourCC.RGBA);
+		});
+	}
+
+	private void initializeI420Buffer(I420Buffer i420) {
+		ByteBuffer dataY = i420.getDataY();
+		int strideY = i420.getStrideY();
+		ByteBuffer dataU = i420.getDataU();
+		int strideU = i420.getStrideU();
+		ByteBuffer dataV = i420.getDataV();
+		int strideV = i420.getStrideV();
+
+		byte value = 0;
+		for (int y = 0; y < HEIGHT; y++) {
+			for (int x = 0; x < WIDTH; x++) {
+				dataY.put(y * strideY + x, value++);
+			}
+		}
+		for (int y = 0; y < HEIGHT / 2; y++) {
+			for (int x = 0; x < WIDTH / 2; x++) {
+				dataU.put(y * strideU + x, value++);
+				dataV.put(y * strideV + x, value++);
+			}
+		}
+	}
+
+	private void initializeRGBAArray(byte[] rgba) {
+		byte value = 0;
+		for (int i = 0; i < rgba.length; i++) {
+			rgba[i] = value++;
+		}
+	}
+
+	private void initializeRGBABuffer(ByteBuffer rgba) {
+		byte value = 0;
+		for (int i = 0; i < rgba.limit(); i++) {
+			rgba.put(value++);
+		}
+	}
+
+	private void verifyI420Buffer(I420Buffer i420, boolean expectingChanges) {
+		assertEquals(WIDTH, i420.getWidth());
+		assertEquals(HEIGHT, i420.getHeight());
+
+		ByteBuffer dataY = i420.getDataY();
+		int strideY = i420.getStrideY();
+		ByteBuffer dataU = i420.getDataU();
+		int strideU = i420.getStrideU();
+		ByteBuffer dataV = i420.getDataV();
+		int strideV = i420.getStrideV();
+
+		if (expectingChanges) {
+			boolean nonZeroY = false;
+			boolean nonZeroU = false;
+			boolean nonZeroV = false;
+
+			for (int y = 0; y < HEIGHT; y++) {
+				for (int x = 0; x < WIDTH; x++) {
+					nonZeroY |= (dataY.get(y * strideY + x) != 0);
+				}
+			}
+			for (int y = 0; y < HEIGHT / 2; y++) {
+				for (int x = 0; x < WIDTH / 2; x++) {
+					nonZeroU |= (dataU.get(y * strideU + x) != 0);
+					nonZeroV |= (dataV.get(y * strideV + x) != 0);
+				}
+			}
+
+			assertTrue(nonZeroY);
+			assertTrue(nonZeroU);
+			assertTrue(nonZeroV);
+		}
+		else {
+			byte value = 0;
+			for (int y = 0; y < HEIGHT; y++) {
+				for (int x = 0; x < WIDTH; x++) {
+					assertEquals(value++, dataY.get(y * strideY + x));
+				}
+			}
+			for (int y = 0; y < HEIGHT / 2; y++) {
+				for (int x = 0; x < WIDTH / 2; x++) {
+					assertEquals(value++, dataU.get(y * strideU + x));
+					assertEquals(value++, dataV.get(y * strideV + x));
+				}
+			}
+		}
+	}
+
+	private void verifyRGBAArray(byte[] rgba, boolean expectingChanges) {
+		assertEquals(4 * WIDTH * HEIGHT, rgba.length);
+
+		if (expectingChanges) {
+			boolean nonZeroR = false;
+			boolean nonZeroG = false;
+			boolean nonZeroB = false;
+
+			for (int i = 0; i < 4 * WIDTH * HEIGHT; i += 4) {
+				byte a = rgba[i + 0];
+				byte b = rgba[i + 1];
+				byte g = rgba[i + 2];
+				byte r = rgba[i + 3];
+				assertEquals((byte) -1, a);
+				nonZeroB |= (b != 0);
+				nonZeroG |= (g != 0);
+				nonZeroR |= (r != 0);
+			}
+
+			assertTrue(nonZeroR);
+			assertTrue(nonZeroG);
+			assertTrue(nonZeroB);
+		}
+		else {
+			byte value = 0;
+			for (int i = 0; i < 4 * WIDTH * HEIGHT; i++) {
+				assertEquals(value++, rgba[i]);
+			}
+		}
+	}
+
+	private void verifyRGBABuffer(ByteBuffer rgba, boolean expectingChanges) {
+		assertEquals(4 * WIDTH * HEIGHT, rgba.limit());
+
+		if (expectingChanges) {
+			boolean nonZeroR = false;
+			boolean nonZeroG = false;
+			boolean nonZeroB = false;
+
+			for (int i = 0; i < 4 * WIDTH * HEIGHT; i += 4) {
+				byte a = rgba.get();
+				byte b = rgba.get();
+				byte g = rgba.get();
+				byte r = rgba.get();
+				assertEquals((byte) -1, a);
+				nonZeroB |= (b != 0);
+				nonZeroG |= (g != 0);
+				nonZeroR |= (r != 0);
+			}
+
+			assertTrue(nonZeroR);
+			assertTrue(nonZeroG);
+			assertTrue(nonZeroB);
+		}
+		else {
+			byte value = 0;
+			for (int i = 0; i < 4 * WIDTH * HEIGHT; i++) {
+				assertEquals(value++, rgba.get());
+			}
+		}
+	}
+
+}


### PR DESCRIPTION
Hey, now that you added `CustomVIdeoSource` that can accept `VideoFrame`s that need `I420Buffer`s,
it might be useful to be able to use RGB frames.

`VideoBufferConverter` has `convertFromI420` to be able to take frames from sinks and convert them to RGB,
so I added `convertToI420` to convert a buffer (`byte[]` or `ByteBuffer`) to `I420Buffer`.
Like the existing `VideoDesktopSource`, this uses `libyuv::ConvertToI420`.

Example usage based on `custom_video_source.md`:
```java
void pushRGBFrame(ByteBuffer rgbBuffer, int width, int height) throws Exception {
    NativeI420Buffer i420Buffer = NativeI420Buffer.allocate(width, height);
    VideoBufferConverter.convertToI420(rgbBuffer, i420Buffer, FourCC.RGBA);
    VideoFrame frame = new VideoFrame(buffer, System.nanoTime());
    videoSource.pushFrame(frame);
    frame.dispose();
}
```

I then added tests for `VideoBufferConverter`:
- testing converting from/to i420 works, with either a `byte[]` or a direct `ByteBuffer` or a non-direct `ByteBuffer` (6 tests)
- testing that if the buffer is too small we get an exception (6 tests)
- testing that read-only bytebuffers work when using them as a source, but not as a destination, whether direct or non-direct (4 tests)

To test the conversion itself did something I generated I420/RGBA data that contained sequential numbers just so it wouldn't be zero or constant (see `initializeI420Buffer`/`initializeRGBAArray`/`initializeRGBABuffer`), then called `VideoBufferConverter` to perform the conversion, and then check that each channel of the destination buffer has at least one non-zero byte (see `verifyI420Buffer`/`verifyRGBAArray`/`verifyRGBABuffer`).

Thanks!