### PR TITLE
fix: return a valid NtpTime from SyncClock::GetNtpTime

### DIFF
--- a/webrtc-jni/src/main/cpp/src/media/SyncClock.cpp
+++ b/webrtc-jni/src/main/cpp/src/media/SyncClock.cpp
@@ -37,7 +37,6 @@ namespace jni
 
     webrtc::NtpTime SyncClock::GetNtpTime() const
     {
-        int64_t ntp_time_ms = webrtc::Clock::GetRealTimeClock()->CurrentNtpInMilliseconds();
-        return webrtc::NtpTime(ntp_time_ms);
+        return webrtc::Clock::GetRealTimeClock()->CurrentNtpTime();
     }
 }


### PR DESCRIPTION
Hello! 👋

When using the new `CustomVideoSource` and pushing frames, the frames seem to be always dropped, and the following warning is [logged by libwebrtc](https://webrtc.googlesource.com/src/+/refs/branch-heads/7204/video/video_stream_encoder.cc#1601) on every frame:
```
[000:234][21574] (video_stream_encoder.cc:1601): Same/old NTP timestamp (922847 <= 922847) for incoming frame. Dropping.
```
The number `922847` here is the `ntp_time_ms` of the `VideoFrame`, and all frames are dropped because this number doesn't change between frames, and the library only sends frame that comes strictly after the previous frame.

`CustomVideoSource` sets `ntp_time_ms` using `SyncClock::GetNtpTime`:
https://github.com/devopvoid/webrtc-java/blob/6e6040337e8e23371e3d945e839d8ac226faef7d/webrtc-jni/src/main/cpp/src/media/video/CustomVideoSource.cpp#L61
https://github.com/devopvoid/webrtc-java/blob/6e6040337e8e23371e3d945e839d8ac226faef7d/webrtc-jni/src/main/cpp/src/media/SyncClock.cpp#L38-L42

The local variable `ntp_time_ms` equals the amount of milliseconds since 1900-01-01, but then it calls the `webrtc::NtpTime` constructor.
This constructor expects a fixed-point 64bit number, where the high 32 bits represent seconds (since 1900-01-01) and the low 32 bits represent a fraction of a second (numerator out of 2^32).
The result of interpreting a value in milliseconds as this fixed-point 64bit value and then converting it back to milliseconds is a number that increases by 1 every 2^32 microseconds, which is a little over 1 hour.
This means that it's sending 1 frame per hour.

To convert from ms to `NtpTime`: `webrtc::Clock::GetRealTimeClock()->ConvertTimestampToNtpTime(Timestamp::Millis(ntp_time_ms))`

Currently the code calls `CurrentNtpInMilliseconds()` which returns `CurrentNtpTime().ToMs()` ([libwebrtc clock.h](https://webrtc.googlesource.com/src/+/refs/branch-heads/7204/system_wrappers/include/clock.h#42)), so a simple fix is to return `CurrentNtpTime()` directly without converting to ms and back. `CustomVideoSource` already calls `.ToMs()` on the `NtpTime` instance.

Thanks!