### PR TITLE
fix: add OnBufferedAmountChange callback to RTCDataChannelObserver

### DIFF
--- a/webrtc-jni/src/main/cpp/include/api/RTCDataChannelObserver.h
+++ b/webrtc-jni/src/main/cpp/include/api/RTCDataChannelObserver.h
@@ -37,6 +37,7 @@ namespace jni
 			// DataChannelObserver implementation.
 			void OnStateChange() override;
 			void OnMessage(const webrtc::DataBuffer & buffer) override;
+			void OnBufferedAmountChange(uint64_t sent_data_size) override;
 
 		private:
 			class JavaRTCDataChannelObserverClass : public JavaClass
@@ -46,6 +47,7 @@ namespace jni
 
 					jmethodID onStateChange;
 					jmethodID onMessage;
+					jmethodID onBufferedAmountChange;
 			};
 
 		private:

--- a/webrtc-jni/src/main/cpp/src/api/RTCDataChannelObserver.cpp
+++ b/webrtc-jni/src/main/cpp/src/api/RTCDataChannelObserver.cpp
@@ -48,11 +48,21 @@ namespace jni
 		ExceptionCheck(env);
 	}
 
+	void RTCDataChannelObserver::OnBufferedAmountChange(uint64_t sent_data_size)
+	{
+		JNIEnv * env = AttachCurrentThread();
+
+		env->CallVoidMethod(observer, javaClass->onBufferedAmountChange, static_cast<jlong>(sent_data_size));
+
+		ExceptionCheck(env);
+	}
+
 	RTCDataChannelObserver::JavaRTCDataChannelObserverClass::JavaRTCDataChannelObserverClass(JNIEnv * env)
 	{
 		jclass cls = FindClass(env, PKG"RTCDataChannelObserver");
 
 		onStateChange = GetMethod(env, cls, "onStateChange", "()V");
 		onMessage = GetMethod(env, cls, "onMessage", "(L" PKG "RTCDataChannelBuffer;)V");
+		onBufferedAmountChange = GetMethod(env, cls, "onBufferedAmountChange", "(J)V");
 	}
 }


### PR DESCRIPTION
Fixes the missing callback method in the `RTCDataChannelObserver` #143