### PR TITLE
Update the sdp field in the RTCIceCandidate class to candidate

### DIFF
--- a/webrtc/src/main/java/dev/onvoid/webrtc/RTCIceCandidate.java
+++ b/webrtc/src/main/java/dev/onvoid/webrtc/RTCIceCandidate.java
@@ -37,9 +37,9 @@ public class RTCIceCandidate {
 	public final int sdpMLineIndex;
 
 	/**
-	 * SDP string representation of this candidate.
+	 * Candidate string representation of this candidate.
 	 */
-	public final String sdp;
+	public final String candidate;
 
 	/**
 	 * The URL of the ICE server which this candidate was gathered from.
@@ -52,11 +52,11 @@ public class RTCIceCandidate {
 	 *
 	 * @param sdpMid        The media stream "identification-tag"
 	 * @param sdpMLineIndex The index (starting at zero) of the media
-	 *                      description in the SDP.
-	 * @param sdp           SDP string representation of the candidate.
+	 *                      description in the Candidate.
+	 * @param candidate     Candidate string representation of the candidate.
 	 */
-	public RTCIceCandidate(String sdpMid, int sdpMLineIndex, String sdp) {
-		this(sdpMid, sdpMLineIndex, sdp, null);
+	public RTCIceCandidate(String sdpMid, int sdpMLineIndex, String candidate) {
+		this(sdpMid, sdpMLineIndex, candidate, null);
 	}
 
 	/**
@@ -65,21 +65,21 @@ public class RTCIceCandidate {
 	 * @param sdpMid        The media stream "identification-tag"
 	 * @param sdpMLineIndex The index (starting at zero) of the media
 	 *                      description in the SDP.
-	 * @param sdp           SDP string representation of the candidate.
+	 * @param candidate     Candidate string representation of the candidate.
 	 * @param serverUrl     The URL of the ICE server.
 	 */
-	public RTCIceCandidate(String sdpMid, int sdpMLineIndex, String sdp,
+	public RTCIceCandidate(String sdpMid, int sdpMLineIndex, String candidate,
 			String serverUrl) {
 		this.sdpMid = sdpMid;
 		this.sdpMLineIndex = sdpMLineIndex;
-		this.sdp = sdp;
+		this.candidate = candidate;
 		this.serverUrl = serverUrl;
 	}
 
 	@Override
 	public String toString() {
-		return String.format("%s@%d [sdpMid=%s, sdpMLineIndex=%s, sdp=%s, serverUrl=%s]",
+		return String.format("%s@%d [sdpMid=%s, sdpMLineIndex=%s, candidate=%s, serverUrl=%s]",
 						RTCIceCandidate.class.getSimpleName(), hashCode(),
-						sdpMid, sdpMLineIndex, sdp, serverUrl);
+						sdpMid, sdpMLineIndex, candidate, serverUrl);
 	}
 }


### PR DESCRIPTION
During actual development, we discovered that an incorrect field description caused the backend to return an incorrect `ice-candidate` to the frontend. This prevented the frontend from correctly initiating a connection request to the backend, resulting in a failed WebRTC connection establishment.

We tested this using the Go language's Pion component and found that it connected successfully. Comparing the message packets revealed the issue was with the field name.

Below is a packet capture. You can see that using the Pion component, the frontend quickly initiates a connection request to the backend, while the WebRTC-Java component does not initiate any requests. After manually changing the `sdp` name to `candidate` on the frontend, the request could be initiated correctly.
 
<img width="1555" height="602" alt="image" src="https://github.com/user-attachments/assets/912bc3ce-dc1b-4fdc-a739-82effb1f976a" />
