### PR TITLE
Fix DesktopSource crash linux X11

### DIFF
--- a/webrtc-jni/src/main/cpp/CMakeLists.txt
+++ b/webrtc-jni/src/main/cpp/CMakeLists.txt
@@ -110,7 +110,7 @@ elseif(LINUX)
         set(CXX_LIBS "-static-libgcc")
     endif()
 
-    target_link_libraries(${PROJECT_NAME} ${CXX_LIBS} pulse udev)
+    target_link_libraries(${PROJECT_NAME} ${CXX_LIBS} pulse udev X11 Xfixes Xrandr Xcomposite Xdamage Xtst Xext Xrender)
 elseif(WIN32)
     target_link_libraries(${PROJECT_NAME} dwmapi.lib mf.lib mfreadwrite.lib mfplat.lib mfuuid.lib shcore.lib)
 endif()

--- a/webrtc-jni/src/main/cpp/dependencies/jni-voithos/CMakeLists.txt
+++ b/webrtc-jni/src/main/cpp/dependencies/jni-voithos/CMakeLists.txt
@@ -68,7 +68,7 @@ elseif(WIN32)
 endif()
 
 set_target_properties(${PROJECT_NAME} PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 20
     CXX_STANDARD_REQUIRED ON
     CXX_EXTENSIONS OFF
 )

--- a/webrtc-jni/src/main/cpp/dependencies/webrtc/CMakeLists.txt
+++ b/webrtc-jni/src/main/cpp/dependencies/webrtc/CMakeLists.txt
@@ -172,7 +172,7 @@ elseif(LINUX)
     pkg_check_modules(DBUS REQUIRED dbus-1)
 
     target_include_directories(${PROJECT_NAME} PUBLIC ${DBUS_INCLUDE_DIRS})
-    target_compile_definitions(${PROJECT_NAME} PUBLIC WEBRTC_LINUX WEBRTC_POSIX WEBRTC_USE_H264)
+    target_compile_definitions(${PROJECT_NAME} PUBLIC WEBRTC_LINUX WEBRTC_POSIX WEBRTC_USE_H264 WEBRTC_USE_X11)
     target_link_libraries(${PROJECT_NAME} X11 Xfixes Xrandr Xcomposite dbus-1)
 elseif(WIN32)
     target_compile_definitions(${PROJECT_NAME} PUBLIC WEBRTC_WIN WEBRTC_USE_H264 NOMINMAX WIN32_LEAN_AND_MEAN NDEBUG)

--- a/webrtc-jni/src/main/cpp/toolchain/x86_64-linux-clang.cmake
+++ b/webrtc-jni/src/main/cpp/toolchain/x86_64-linux-clang.cmake
@@ -4,7 +4,7 @@ set(CMAKE_C_COMPILER        /opt/clang/bin/clang)
 set(CMAKE_CXX_COMPILER      /opt/clang/bin/clang++)
 set(CMAKE_AR                /opt/clang/bin/llvm-ar)
 
-set(CMAKE_CXX_FLAGS         "${CMAKE_CXX_FLAGS} -nostdinc++ -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_EXTENSIVE")
+set(CMAKE_CXX_FLAGS         "${CMAKE_CXX_FLAGS} -nostdinc++ -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_NONE")
 set(CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++ -v -Wl,--verbose")
 
 foreach(LINKER SHARED_LINKER)


### PR DESCRIPTION
If I use this code to list desktop sources https://jrtc.dev/guide/video/desktop-capture#desktop-video-source-selection

It works on 0.10.0.
Crashes on 0.11.0 and superior (also on main).

From what i understood investigating:
* Some X libs were missing (Xfixes Xdamage Xtest ...)
* jni-voithos is cpp14 and doesn't support hardening which is present in cpp20.
* webrtc-java is cpp20 and hardening is enabled due to toolchain (clang) defaults.
 * libwebrtc.a has hardening disabled.
For some reason way too low level for me, having this kind of mix could be dangerous for ABI stability.
Due to that mismatch, the jenv pointer could get corrupted. It turns out this is not my issue, it came up while investigating. Not sure if it's relevant or LLM rambling.

I then figured out that WEBRTC_USE_X11 missing was my issue (+ Xlibs). Tested on v0.14.0 and main with that single commit.

Also tested the set of 3 commits on v0.14.0 and main.
