### PR TITLE
Fix/linux desktop capturer x11 abi

### DIFF
--- a/webrtc-jni/src/main/cpp/dependencies/webrtc/CMakeLists.txt
+++ b/webrtc-jni/src/main/cpp/dependencies/webrtc/CMakeLists.txt
@@ -172,7 +172,7 @@ elseif(LINUX)
     pkg_check_modules(DBUS REQUIRED dbus-1)
 
     target_include_directories(${PROJECT_NAME} PUBLIC ${DBUS_INCLUDE_DIRS})
-    target_compile_definitions(${PROJECT_NAME} PUBLIC WEBRTC_LINUX WEBRTC_POSIX WEBRTC_USE_H264)
+    target_compile_definitions(${PROJECT_NAME} PUBLIC WEBRTC_LINUX WEBRTC_POSIX WEBRTC_USE_H264 WEBRTC_USE_X11)
     target_link_libraries(${PROJECT_NAME} X11 Xfixes Xrandr Xcomposite dbus-1)
 elseif(WIN32)
     target_compile_definitions(${PROJECT_NAME} PUBLIC WEBRTC_WIN WEBRTC_USE_H264 NOMINMAX WIN32_LEAN_AND_MEAN NDEBUG)

--- a/webrtc-jni/src/main/cpp/src/JNI_ScreenCapturer.cpp
+++ b/webrtc-jni/src/main/cpp/src/JNI_ScreenCapturer.cpp
@@ -21,5 +21,10 @@
 JNIEXPORT void JNICALL Java_dev_onvoid_webrtc_media_video_desktop_ScreenCapturer_initialize
 (JNIEnv * env, jobject caller)
 {
-    SetHandle(env, caller, new jni::DesktopCapturer(true));
+	try {
+		SetHandle(env, caller, new jni::DesktopCapturer(true));
+	}
+	catch (...) {
+		ThrowCxxJavaException(env);
+	}
 }

--- a/webrtc-jni/src/main/cpp/src/JNI_WindowCapturer.cpp
+++ b/webrtc-jni/src/main/cpp/src/JNI_WindowCapturer.cpp
@@ -21,5 +21,10 @@
 JNIEXPORT void JNICALL Java_dev_onvoid_webrtc_media_video_desktop_WindowCapturer_initialize
 (JNIEnv * env, jobject caller)
 {
-    SetHandle(env, caller, new jni::DesktopCapturer(false));
+	try {
+		SetHandle(env, caller, new jni::DesktopCapturer(false));
+	}
+	catch (...) {
+		ThrowCxxJavaException(env);
+	}
 }

--- a/webrtc-jni/src/main/cpp/src/media/video/desktop/DesktopCapturer.cpp
+++ b/webrtc-jni/src/main/cpp/src/media/video/desktop/DesktopCapturer.cpp
@@ -19,6 +19,7 @@
 #include "modules/desktop_capture/desktop_capturer.h"
 #include "modules/desktop_capture/desktop_capture_options.h"
 #include "modules/desktop_capture/desktop_and_cursor_composer.h"
+#include "rtc_base/logging.h"
 
 namespace jni
 {
@@ -36,14 +37,22 @@ namespace jni
 		options.set_allow_directx_capturer(true);
 #endif
 
-		if (screenCapturer) {
-			capturer = std::make_unique<webrtc::DesktopAndCursorComposer>(
-				webrtc::DesktopCapturer::CreateScreenCapturer(options), options);
+		std::unique_ptr<webrtc::DesktopCapturer> inner = screenCapturer
+			? webrtc::DesktopCapturer::CreateScreenCapturer(options)
+			: webrtc::DesktopCapturer::CreateWindowCapturer(options);
+
+		if (!inner) {
+			RTC_LOG(LS_ERROR) << (screenCapturer
+				? "DesktopCapturer: CreateScreenCapturer returned null. "
+				  "Possible causes: missing X11/XDAMAGE extension, Wayland "
+				  "session without PipeWire support, or snap confinement."
+				: "DesktopCapturer: CreateWindowCapturer returned null. "
+				  "Possible causes: missing X11/XFIXES extension or snap confinement.");
+			// Leave capturer as nullptr; callers check via GetSourceList returning false.
+			return;
 		}
-		else {
-			capturer = std::make_unique<webrtc::DesktopAndCursorComposer>(
-				webrtc::DesktopCapturer::CreateWindowCapturer(options), options);
-		}
+
+		capturer = std::make_unique<webrtc::DesktopAndCursorComposer>(std::move(inner), options);
 	}
 
 	DesktopCapturer::~DesktopCapturer()
@@ -53,6 +62,8 @@ namespace jni
 
 	void DesktopCapturer::Start(webrtc::DesktopCapturer::Callback * callback)
 	{
+		if (!capturer) return;
+
 		capturer->Start(callback);
 
 		if (focusSelectedSource) {
@@ -62,16 +73,20 @@ namespace jni
 
 	void DesktopCapturer::SetMaxFrameRate(uint32_t max_frame_rate)
 	{
+		if (!capturer) return;
 		capturer->SetMaxFrameRate(max_frame_rate);
 	}
 
 	void DesktopCapturer::SetSharedMemoryFactory(std::unique_ptr<webrtc::SharedMemoryFactory> factory)
 	{
+		if (!capturer) return;
 		capturer->SetSharedMemoryFactory(std::move(factory));
 	}
 
 	void DesktopCapturer::CaptureFrame()
 	{
+		if (!capturer) return;
+
 #if defined(WEBRTC_MAC)
 		CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0, true);
 #endif
@@ -81,21 +96,25 @@ namespace jni
 
 	void DesktopCapturer::SetExcludedWindow(webrtc::WindowId window)
 	{
+		if (!capturer) return;
 		capturer->SetExcludedWindow(window);
 	}
 
 	bool DesktopCapturer::GetSourceList(webrtc::DesktopCapturer::SourceList * sources)
 	{
+		if (!capturer) return false;
 		return capturer->GetSourceList(sources);
 	}
 
 	bool DesktopCapturer::SelectSource(webrtc::DesktopCapturer::SourceId id)
 	{
+		if (!capturer) return false;
 		return capturer->SelectSource(id);
 	}
 
 	bool DesktopCapturer::FocusOnSelectedSource()
 	{
+		if (!capturer) return false;
 		return capturer->FocusOnSelectedSource();
 	}
 
@@ -106,6 +125,7 @@ namespace jni
 
 	bool DesktopCapturer::IsOccluded(const webrtc::DesktopVector & pos)
 	{
+		if (!capturer) return false;
 		return capturer->IsOccluded(pos);
 	}
 }


### PR DESCRIPTION
  ## Problem

  On Linux with WebRTC m140 (branch 7339), constructing `DesktopAndCursorComposer`
  crashes with SIGSEGV. The root cause is an ABI mismatch in `DesktopCaptureOptions`:

  The prebuilt WebRTC library is compiled with `use_x11=true`, which adds
  X11-specific fields to `DesktopCaptureOptions` (conditional on `WEBRTC_USE_X11`).
  The JNI CMake build already links against `X11 Xfixes Xrandr Xcomposite` but did
  not define `WEBRTC_USE_X11` as a preprocessor symbol. This caused the struct
  layout seen by JNI code to differ from the one in the library → reading out of
  bounds when passing `options` to `DesktopAndCursorComposer` → SIGSEGV.

  This affects all Linux architectures (x86-64, arm, arm64) and all distributions.
  It was introduced as a regression with the m140 update.

  ## Fix

  1. **Root cause** (`CMakeLists.txt`): add `WEBRTC_USE_X11` to Linux compile
     definitions so the JNI code and the WebRTC library agree on the struct layout.

  2. **JNI safety** (`DesktopCapturer.cpp`, `JNI_ScreenCapturer.cpp`,
     `JNI_WindowCapturer.cpp`): replace the `throw` in the constructor (which would
     cross the JNI boundary as undefined behavior) with a log + early return, and
     add null-guards on all methods. The JNI entry points now catch any remaining
     C++ exceptions and convert them to Java exceptions.

  ## Testing

  Verified on Ubuntu 24.04 (X11 session), linux_x86-64.
  Screen and window capture work correctly.