### PR TITLE
fix error on MacOS when the application shuts down

### DIFF
--- a/webrtc-jni/src/main/cpp/dependencies/jni-voithos/include/JavaEnum.h
+++ b/webrtc-jni/src/main/cpp/dependencies/jni-voithos/include/JavaEnum.h
@@ -53,6 +53,7 @@ namespace jni
 
 			~JavaEnum()
 			{
+			    values.release();
 			}
 
 			JavaLocalRef<jobject> toJava(JNIEnv * env, const T & nativeType) const

--- a/webrtc-jni/src/main/cpp/dependencies/jni-voithos/include/JavaFactory.h
+++ b/webrtc-jni/src/main/cpp/dependencies/jni-voithos/include/JavaFactory.h
@@ -26,6 +26,7 @@ namespace jni
 
 			virtual ~JavaFactory()
 			{
+			    javaClass.release();
 			}
 
 			virtual JavaLocalRef<jobject> create(JNIEnv * env, const T * nativeObject) const


### PR DESCRIPTION
The error is triggered when closing the application via the dock on macOS by clicking the “Finish" button. The same error will occur if you complete the process via “System Monitoring”

[hs_err_pid55309.log](https://github.com/user-attachments/files/28795447/hs_err_pid55309.log)
[hs_err_pid55757.log](https://github.com/user-attachments/files/28795451/hs_err_pid55757.log)
[hs_err_pid55614.log](https://github.com/user-attachments/files/28795452/hs_err_pid55614.log)
[hs_err_pid49024.log](https://github.com/user-attachments/files/28795454/hs_err_pid49024.log)
[hs_err_pid55016.log](https://github.com/user-attachments/files/28795455/hs_err_pid55016.log)
[Translated Report 1.docx](https://github.com/user-attachments/files/28795629/Translated.Report.1.docx)
[Translated Report 2.docx](https://github.com/user-attachments/files/28795635/Translated.Report.2.docx)
[Translated Report 3.rtf](https://github.com/user-attachments/files/28795636/Translated.Report.3.rtf)
