### PR TITLE
fix: honor the buffer window in every send path

### DIFF
--- a/webrtc/src/main/java/dev/onvoid/webrtc/RTCDataChannel.java
+++ b/webrtc/src/main/java/dev/onvoid/webrtc/RTCDataChannel.java
@@ -143,7 +143,10 @@ public class RTCDataChannel extends DisposableNativeObject {
 	public native void dispose();
 
 	/**
-	 * Sends data in the provided buffer to the remote peer.
+	 * Sends data in the provided buffer to the remote peer. Only the bytes
+	 * between the buffer's position and limit are sent, for heap and direct
+	 * buffers alike. The buffer is read through a duplicate, so the caller's
+	 * position is left untouched.
 	 *
 	 * @param buffer The buffer to be queued for transmission.
 	 *
@@ -154,21 +157,37 @@ public class RTCDataChannel extends DisposableNativeObject {
 		ByteBuffer data = buffer.data;
 
 		if (data.isDirect()) {
-			sendDirectBuffer(data, buffer.binary);
-		}
-		else {
-			byte[] arrayBuffer;
-
-			if (data.hasArray()) {
-				arrayBuffer = data.array();
+			if (data.position() == 0 && data.limit() == data.capacity()) {
+				sendDirectBuffer(data, buffer.binary);
 			}
 			else {
-				arrayBuffer = new byte[data.remaining()];
-				data.get(arrayBuffer);
+				ByteBuffer window = ByteBuffer.allocateDirect(data.remaining());
+				window.put(data.duplicate());
+				window.flip();
+				sendDirectBuffer(window, buffer.binary);
 			}
-
-			sendByteArrayBuffer(arrayBuffer, buffer.binary);
 		}
+		else {
+			sendByteArrayBuffer(copyWindow(data), buffer.binary);
+		}
+	}
+
+	/**
+	 * Copies the readable window of a heap buffer, position to limit, into a
+	 * fresh array for the byte array send path, which transmits whole arrays.
+	 * The backing array is handed over directly only when the window covers
+	 * it exactly; bytes outside the window (a nonzero position, a short
+	 * limit, an array offset) must never reach the wire. Reads through a
+	 * duplicate, so the caller's position is left untouched.
+	 */
+	private static byte[] copyWindow(ByteBuffer data) {
+		if (data.hasArray() && data.arrayOffset() == 0 && data.position() == 0
+				&& data.remaining() == data.array().length) {
+			return data.array();
+		}
+		byte[] window = new byte[data.remaining()];
+		data.duplicate().get(window);
+		return window;
 	}
 
 	private native void sendDirectBuffer(ByteBuffer buffer, boolean binary);


### PR DESCRIPTION
RTCDataChannel.send behaves differently depending on the buffer it is handed: a heap buffer with an accessible backing array sends the entire backing array regardless of position and limit, a read only heap buffer honors the window, and a direct buffer sends the full capacity. Any caller that slices, flips, or reuses a buffer silently transmits the wrong bytes.

All paths now send exactly the bytes between position and limit, read through a duplicate so the caller's buffer state is untouched. Java only, no native changes.
