### PR TITLE
build: derive the WebRTC cache branch from the pom and guard deploys

### DIFF
--- a/.github/actions/build-macos-x86_64/action.yml
+++ b/.github/actions/build-macos-x86_64/action.yml
@@ -23,6 +23,10 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Derive the WebRTC cache branch from the pom
+      run: echo "WEBRTC_CACHE_BRANCH=$(sed -n 's|.*<webrtc.branch>branch-heads/\([^<]*\)</webrtc.branch>.*|\1|p' webrtc-jni/pom.xml)" >> "$GITHUB_ENV"
+      shell: bash
+
     - name: Set up WebRTC cache
       uses: actions/cache@v4
       with:
@@ -56,7 +60,7 @@ runs:
       shell: bash
 
     - name: Deploy
-      if: ${{ github.event_name != 'pull_request' }}
+      if: ${{ github.event_name != 'pull_request' && github.repository == 'devopvoid/webrtc-java' }}
       env:
         MAVEN_USERNAME: ${{ inputs.maven-username }}
         MAVEN_TOKEN: ${{ inputs.maven-password }}

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -23,6 +23,10 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Derive the WebRTC cache branch from the pom
+      run: echo "WEBRTC_CACHE_BRANCH=$(sed -n 's|.*<webrtc.branch>branch-heads/\([^<]*\)</webrtc.branch>.*|\1|p' webrtc-jni/pom.xml)" >> "$GITHUB_ENV"
+      shell: bash
+
     - name: Set up WebRTC cache
       uses: actions/cache@v4
       with:
@@ -63,7 +67,7 @@ runs:
       shell: bash
 
     - name: Deploy
-      if: ${{ github.event_name != 'pull_request' }}
+      if: ${{ github.event_name != 'pull_request' && github.repository == 'devopvoid/webrtc-java' }}
       env:
         MAVEN_USERNAME: ${{ inputs.maven-username }}
         MAVEN_TOKEN: ${{ inputs.maven-password }}

--- a/.github/actions/release-macos-x86_64/action.yml
+++ b/.github/actions/release-macos-x86_64/action.yml
@@ -31,6 +31,10 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Derive the WebRTC cache branch from the pom
+      run: echo "WEBRTC_CACHE_BRANCH=$(sed -n 's|.*<webrtc.branch>branch-heads/\([^<]*\)</webrtc.branch>.*|\1|p' webrtc-jni/pom.xml)" >> "$GITHUB_ENV"
+      shell: bash
+
     - name: Set up WebRTC cache
       uses: actions/cache@v4
       with:

--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -31,6 +31,10 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Derive the WebRTC cache branch from the pom
+      run: echo "WEBRTC_CACHE_BRANCH=$(sed -n 's|.*<webrtc.branch>branch-heads/\([^<]*\)</webrtc.branch>.*|\1|p' webrtc-jni/pom.xml)" >> "$GITHUB_ENV"
+      shell: bash
+
     - name: Set up WebRTC cache
       uses: actions/cache@v4
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,6 @@ on:
   workflow_dispatch:
 
 env:
-  WEBRTC_CACHE_BRANCH: 7339
   WEBRTC_CHECKOUT_FOLDER: webrtc
   WEBRTC_INSTALL_FOLDER: webrtc/build
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,6 @@ on:
         default: "X.Y.Z-SNAPSHOT"
 
 env:
-  WEBRTC_CACHE_BRANCH: 7339
   WEBRTC_CHECKOUT_FOLDER: webrtc
   WEBRTC_INSTALL_FOLDER: webrtc/build
 


### PR DESCRIPTION
Two CI robustness issues in one commit:

The WebRTC cache branch is pinned as a literal env in the workflows and must be kept in sync with webrtc-jni/pom.xml by hand; when they drift, lanes restore caches for the wrong engine branch. A setup step now derives the value from the pom, making the pom the single source of truth.

The Sonatype deploy steps run unconditionally, so on any fork every fully successful lane concludes as failure from the credentialless 401, and because cache saves are gated on success, fork builds can never warm their caches either. Deploys are now skipped on pull requests and guarded to the devopvoid/webrtc-java repository. Behavior for this repository's own pushes is unchanged.
