### PR TITLE
test: fix the intermittent PortAllocatorConfigIntegrationTest failures

### DIFF
--- a/webrtc/src/test/java/dev/onvoid/webrtc/PortAllocatorConfigIntegrationTest.java
+++ b/webrtc/src/test/java/dev/onvoid/webrtc/PortAllocatorConfigIntegrationTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -59,6 +60,11 @@ class PortAllocatorConfigIntegrationTest extends TestBase {
 		// Create an SDP offer /answer and set descriptions.
 		callee.setRemoteDescription(caller.createOffer());
 		caller.setRemoteDescription(callee.createAnswer());
+
+		// Both descriptions are applied now; deliver the candidates gathered
+		// during the exchange and forward directly from here on.
+		caller.flushCandidates();
+		callee.flushCandidates();
 
 		// Wait until connected (with a timeout to avoid hanging tests).
 		assertTrue(caller.awaitConnected(30, TimeUnit.SECONDS), "Caller failed to connect in time");
@@ -118,7 +124,9 @@ class PortAllocatorConfigIntegrationTest extends TestBase {
 		private final RTCPeerConnection pc;
 		private RTCPeerConnection remote;
 		private final CountDownLatch connected = new CountDownLatch(1);
-		final List<String> candidates = new ArrayList<>();
+		private final List<RTCIceCandidate> pendingCandidates = new ArrayList<>();
+		private boolean forwardDirectly;
+		final List<String> candidates = new CopyOnWriteArrayList<>();
 
 
 		AllocPeer(PeerConnectionFactory factory, RTCConfiguration cfg) {
@@ -165,12 +173,37 @@ class PortAllocatorConfigIntegrationTest extends TestBase {
 			pc.close();
 		}
 
+		/**
+		 * Delivers the candidates buffered during the offer/answer exchange
+		 * and switches to direct forwarding. Trickling starts inside
+		 * createOffer/createAnswer via setLocalDescription, so early
+		 * candidates would reach the remote peer before it has a remote
+		 * description; the native stack rejects such candidates and they
+		 * would be lost for good, leaving ICE without a candidate pair.
+		 */
+		void flushCandidates() {
+			List<RTCIceCandidate> buffered;
+			synchronized (this) {
+				forwardDirectly = true;
+				buffered = new ArrayList<>(pendingCandidates);
+				pendingCandidates.clear();
+			}
+			for (RTCIceCandidate candidate : buffered) {
+				remote.addIceCandidate(candidate);
+			}
+		}
+
 		@Override
 		public void onIceCandidate(RTCIceCandidate candidate) {
 			candidates.add(candidate.sdp);
-			if (remote != null) {
-				remote.addIceCandidate(candidate);
+
+			synchronized (this) {
+				if (!forwardDirectly) {
+					pendingCandidates.add(candidate);
+					return;
+				}
 			}
+			remote.addIceCandidate(candidate);
 		}
 
 		@Override


### PR DESCRIPTION
iceCandidatesRespectPortAllocatorConfig fails intermittently on CI with "Caller failed to connect in time" and passes when run again (this week: the first runs on #245 and #248, the post merge run on main, and the current run on #249). The cause is a race in the test, not in the library. Candidate gathering starts inside createOffer and createAnswer through their setLocalDescription call, and the test forwards every candidate to the remote peer straight from onIceCandidate, while the test thread has not yet applied the corresponding remote descriptions. A candidate that arrives before its receiver has a remote description is rejected by the native stack and never retried. ICE usually connects anyway, because one surviving direction rescues the other through peer reflexive candidates; when both directions lose every candidate, no pair ever forms and the test burns the entire timeout. That matches the observed failures, which exhaust the full wait rather than connecting slowly. Loaded CI runners widen the race window, which is why this fires on CI and rarely on developer machines.

The peers now buffer outgoing candidates; the test delivers them once both descriptions are applied and forwards directly from then on, so no candidate can reach a peer that cannot accept it. The candidates list also became a CopyOnWriteArrayList, since it is written on the signaling thread and read on the test thread. I have not verified this with a CI run, and a green run would not prove much for an intermittent failure anyway; the fix follows from the mechanism above, so the real confirmation is the failures no longer recurring. Test only, no library code changes. Independent of #249, which raises this test's timeout; the two merge cleanly in either order.
