### PR TITLE
feat: offer both screens and windows in the Wayland portal picker

### DIFF
--- a/webrtc-jni/src/main/cpp/src/media/video/VideoTrackDesktopSource.cpp
+++ b/webrtc-jni/src/main/cpp/src/media/video/VideoTrackDesktopSource.cpp
@@ -266,18 +266,27 @@ namespace jni
 		options.set_prefer_cursor_embedded(true);
 #endif
 
-		std::unique_ptr<webrtc::DesktopCapturer> capturer;
+		std::unique_ptr<webrtc::DesktopCapturer> inner;
 
-		if (sourceIsWindow) {
-			capturer.reset(new webrtc::DesktopAndCursorComposer(
-				webrtc::DesktopCapturer::CreateWindowCapturer(options),
-				options));
+#if defined(WEBRTC_USE_PIPEWIRE)
+		// Wayland: request "any screen content" so the xdg-desktop-portal picker
+		// offers both monitors and application windows in a single dialog (the
+		// same CaptureType::kAnyScreenContent Chromium uses for getDisplayMedia).
+		// CreateGenericCapturer returns null when not running under Wayland or
+		// when PipeWire is disallowed, in which case we fall back to the
+		// type-specific capturers below. The portal handles the actual source
+		// selection, so sourceIsWindow is irrelevant on this path.
+		inner = webrtc::DesktopCapturer::CreateGenericCapturer(options);
+#endif
+
+		if (!inner) {
+			inner = sourceIsWindow
+				? webrtc::DesktopCapturer::CreateWindowCapturer(options)
+				: webrtc::DesktopCapturer::CreateScreenCapturer(options);
 		}
-		else {
-			capturer.reset(new webrtc::DesktopAndCursorComposer(
-				webrtc::DesktopCapturer::CreateScreenCapturer(options),
-				options));
-		}
+
+		std::unique_ptr<webrtc::DesktopCapturer> capturer;
+		capturer.reset(new webrtc::DesktopAndCursorComposer(std::move(inner), options));
 
 		if (!capturer->SelectSource(sourceId)) {
 			terminate();


### PR DESCRIPTION
## Summary

Under Wayland the `xdg-desktop-portal` screen-cast dialog only offered the
source kind that matched the capturer we created: `CreateScreenCapturer`
showed just the monitor list, `CreateWindowCapturer` just the window list.
A user picking "share a window" from a screen-capture entry point (or vice
versa) had no way to get there.

This routes the Wayland/PipeWire path through
`DesktopCapturer::CreateGenericCapturer`, which requests
`CaptureType::kAnyScreenContent` — the same capture type Chromium uses for
`getDisplayMedia`. The portal then presents both the monitor and the
application-window tabs in a single dialog and the user chooses.

## Details

- Only active when `WEBRTC_USE_PIPEWIRE` is defined.
- `CreateGenericCapturer` returns `null` when not running under Wayland or
  when PipeWire is disallowed; in that case the code falls back to the
  existing type-specific `CreateWindowCapturer` / `CreateScreenCapturer`
  based on `sourceIsWindow`, so **X11, Windows and macOS behaviour is
  unchanged**.
- The selected capturer is still wrapped in `DesktopAndCursorComposer`, as
  before.
- On the portal path the actual source selection is done by the portal
  dialog, so `sourceIsWindow` is not consulted there.

## Files

- `webrtc-jni/src/main/cpp/src/media/video/VideoTrackDesktopSource.cpp`

## Testing

- Wayland + PipeWire (GNOME): portal dialog now shows both "Entire Screen"
  and "Window" tabs; sharing a monitor and sharing a window both work.
- X11: unchanged, still uses the X11 screen/window capturers.
- Windows: unchanged (WGC path).
