### PR TITLE
test: give the DTMF completion wait more headroom

### DIFF
--- a/webrtc/src/test/java/dev/onvoid/webrtc/RTCDtmfSenderTests.java
+++ b/webrtc/src/test/java/dev/onvoid/webrtc/RTCDtmfSenderTests.java
@@ -70,7 +70,11 @@ class RTCDtmfSenderTests extends TestBase {
         }
 
         boolean awaitCompletion() throws InterruptedException {
-            return completedLatch.await(1, TimeUnit.SECONDS);
+            // The longest sequence in these tests needs 720 ms of tone time,
+            // and timer scheduling plus the callback add about 240 ms, which
+            // leaves one second almost no margin. The latch returns when the
+            // sequence completes, so a five second bound costs nothing on a pass.
+            return completedLatch.await(5, TimeUnit.SECONDS);
         }
     }
 


### PR DESCRIPTION
`RTCDtmfSenderTests` waits one second for a tone sequence to complete, a bound introduced with the observer latch in a5cdb18. The longest sequence in the suite needs 720 ms of tone time. Timer scheduling and the callback into Java add about 240 ms on top, so the bound leaves roughly 50 ms of margin and ordinary scheduling jitter is enough to cross it.

I hit this twice in a row on the Intel macOS lane in [this run](https://github.com/SendableMetatype/webrtc-java-upstream/actions/runs/32590540783) on my fork, both attempts, while the same tree passed everywhere else. The failing test's two sequences took 1.785 s together, which matches the estimate.

The change raises the wait to five seconds. The latch returns as soon as the sequence completes, so a passing test takes exactly as long as before, and only a real hang waits the full five seconds. Runs with this change passed the test on every lane, both [with warm caches](https://github.com/SendableMetatype/webrtc-java-upstream/actions/runs/32591767393) and [cold](https://github.com/SendableMetatype/webrtc-java-upstream/actions/runs/33971743040). Green runs prove little for an intermittent failure, so the arithmetic above is the actual argument.
