### PR TITLE
fix: keep JNI thread handling quiet and correct on JVM shutdown

### DIFF
--- a/webrtc-jni/src/main/cpp/dependencies/jni-voithos/include/JavaThreadEnv.h
+++ b/webrtc-jni/src/main/cpp/dependencies/jni-voithos/include/JavaThreadEnv.h
@@ -23,6 +23,7 @@ namespace jni
 		private:
 			JavaVM * vm;
 			JNIEnv * env;
+			bool attached;
 	};
 }
 

--- a/webrtc-jni/src/main/cpp/dependencies/jni-voithos/src/JavaThreadEnv.cpp
+++ b/webrtc-jni/src/main/cpp/dependencies/jni-voithos/src/JavaThreadEnv.cpp
@@ -7,33 +7,30 @@
 
 #include "JavaThreadEnv.h"
 
-#include <iostream>
-#include <thread>
-
 namespace jni
 {
 	JavaThreadEnv::JavaThreadEnv(JavaVM * vm) :
 		vm(vm),
-		env(nullptr)
+		env(nullptr),
+		attached(false)
 	{
 		int status = vm->GetEnv(reinterpret_cast<void**>(&env), JNI_VERSION_1_6);
 
 		if (status == JNI_EDETACHED) {
-			if (vm->AttachCurrentThread(reinterpret_cast<void**>(&env), NULL) != 0) {
-				std::cout << "VM attach current thread failed" << std::endl;
+			if (vm->AttachCurrentThread(reinterpret_cast<void**>(&env), NULL) == JNI_OK) {
+				attached = true;
 			}
-		}
-
-		if (env == nullptr) {
-			std::cout << "Failed to attach thread " << std::this_thread::get_id() << std::endl;
+			else {
+				env = nullptr;
+			}
 		}
 	}
 
 	JavaThreadEnv::~JavaThreadEnv()
 	{
-		vm->DetachCurrentThread();
-
-		//std::cout << "Dettached thread " << std::this_thread::get_id() << std::endl;
+		if (attached) {
+			vm->DetachCurrentThread();
+		}
 	}
 
 	JNIEnv * JavaThreadEnv::getEnv() const

--- a/webrtc-jni/src/main/cpp/src/rtc/LogSink.cpp
+++ b/webrtc-jni/src/main/cpp/src/rtc/LogSink.cpp
@@ -35,6 +35,10 @@ namespace jni
 	{
 		JNIEnv * env = AttachCurrentThread();
 
+		if (env == nullptr) {
+			return;
+		}
+
 		JavaLocalRef<jobject> jSeverity = JavaEnums::toJava(env, severity);
 		JavaLocalRef<jstring> jMessage = JavaString::toJava(env, message);
 


### PR DESCRIPTION
When the JVM shuts down while libwebrtc threads are still running, their callbacks into Java fail to attach. The per-thread JNI helper then prints "Failed to attach thread" to stdout for each of them, and the log sink goes on to call into the null environment it got back.

This PR includes a commit by Joshua Castle (Kas-tle), who maintains [a downstream fork of this library](https://github.com/Kas-tle/webrtc-java), kept under his authorship. It changes three things:

* The helper remembers whether it attached the thread itself, and detaches only those. Before, the destructor detached every thread, including threads that were attached before the helper saw them.
* When attaching fails, the helper leaves the environment null and prints nothing.
* The log sink returns early when it gets a null environment instead of calling into it.

Validation on my fork: [this run](https://github.com/SendableMetatype/webrtc-java-upstream/actions/runs/33987881170) builds and tests on all six platforms.
