### PR TITLE
ci: test the windows arm64 natives on a native runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,14 @@ jobs:
           maven-username: ${{ secrets.MAVEN_USERNAME }}
           maven-password: ${{ secrets.MAVEN_TOKEN }}
 
+      - name: Upload natives for native testing
+        if: matrix.platform.name == 'windows_arm64'
+        uses: actions/upload-artifact@v4
+        with:
+          name: natives-${{ matrix.platform.name }}
+          path: webrtc-jni/target/webrtc-java-*.jar
+          if-no-files-found: error
+
   build-linux:
     strategy:
       fail-fast: false
@@ -126,11 +134,17 @@ jobs:
           maven-password: ${{ secrets.MAVEN_TOKEN }}
 
   test-natives:
-    needs: build-linux
+    needs: [build-windows, build-linux]
     strategy:
       fail-fast: false
       matrix:
         platform:
+          - name: windows_arm64
+            runs-on: windows-11-arm
+            classifier: windows-aarch64
+            profile: windows-aarch64
+            java-distribution: microsoft
+            java-architecture: aarch64
           - name: linux_arm64
             runs-on: ubuntu-22.04-arm
             classifier: linux-aarch64


### PR DESCRIPTION
The `windows_arm64` lane cross-compiles on windows-2022 and skips its tests, as the Linux cross lanes did before #267. This PR gives it the same native test job: the lane uploads the classifier jar it built, and a `windows-11-arm` entry in the `test-natives` matrix downloads that jar, installs it into the local repository, and runs the `webrtc` module's test suite against it with an arm64 JDK. The Microsoft build is the setup-java distribution that ships JDK 17 for Windows aarch64. The arm runner image has no Maven, which the action already handles.

