### PR TITLE
fix: keep libwebrtc quiet by default and make logToDebug work again

### DIFF
--- a/webrtc-jni/src/main/cpp/src/JNI_Logging.cpp
+++ b/webrtc-jni/src/main/cpp/src/JNI_Logging.cpp
@@ -23,7 +23,38 @@
 
 #include "rtc_base/logging.h"
 
+#include <cstdio>
 #include <memory>
+#include <mutex>
+
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
+namespace
+{
+	// libwebrtc no longer lets LogMessage::LogToDebug change the severity of its
+	// own debug output after the logging configuration is initialized. A sink
+	// registered with AddLogToStream can be added and removed at any time, so
+	// logToDebug is implemented with one that writes where libwebrtc used to:
+	// the debugger output on Windows and stderr everywhere.
+	class DebugLogSink : public webrtc::LogSink
+	{
+		public:
+			void OnLogMessage(const std::string & message) override
+			{
+#ifdef _WIN32
+				OutputDebugStringA(message.c_str());
+#endif
+				fputs(message.c_str(), stderr);
+				fflush(stderr);
+			}
+	};
+
+	DebugLogSink debugLogSink;
+	bool debugLogSinkAttached = false;
+	std::mutex debugLogSinkMutex;
+}
 
 JNIEXPORT void JNICALL Java_dev_onvoid_webrtc_logging_Logging_addLogSink
 (JNIEnv * env, jclass caller, jobject jseverity, jobject jsink)
@@ -53,8 +84,22 @@ JNIEXPORT void JNICALL Java_dev_onvoid_webrtc_logging_Logging_logToDebug
 {
 	int rtcSeverity = jni::JavaEnums::toNative<webrtc::LoggingSeverity>(env, jseverity);
 
-	if (rtcSeverity >= webrtc::LS_VERBOSE && rtcSeverity <= webrtc::LS_NONE) {
-		webrtc::LogMessage::LogToDebug(static_cast<webrtc::LoggingSeverity>(rtcSeverity));
+	if (rtcSeverity < webrtc::LS_VERBOSE || rtcSeverity > webrtc::LS_NONE) {
+		return;
+	}
+
+	auto severity = static_cast<webrtc::LoggingSeverity>(rtcSeverity);
+
+	std::lock_guard<std::mutex> lock(debugLogSinkMutex);
+
+	if (debugLogSinkAttached) {
+		webrtc::LogMessage::RemoveLogToStream(&debugLogSink);
+		debugLogSinkAttached = false;
+	}
+
+	if (severity != webrtc::LS_NONE) {
+		webrtc::LogMessage::AddLogToStream(&debugLogSink, severity);
+		debugLogSinkAttached = true;
 	}
 }
 

--- a/webrtc-jni/src/main/cpp/src/JNI_WebRTC.cpp
+++ b/webrtc-jni/src/main/cpp/src/JNI_WebRTC.cpp
@@ -19,6 +19,8 @@
 #include "JavaUtils.h"
 #include "WebRTCContext.h"
 
+#include "rtc_base/logging.h"
+
 #include <jni.h>
 
 jni::JavaContext * javaContext = nullptr;
@@ -30,6 +32,16 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM * vm, void * reserved)
 	if (vm->GetEnv(reinterpret_cast<void **>(&env), JNI_VERSION_1_6) != JNI_OK) {
 		return -1;
 	}
+
+	// libwebrtc initializes its logging configuration on the first log line,
+	// with everything from LS_INFO upwards written to stderr, and the
+	// configuration can be set only once. Initialize it here, before anything
+	// can log, so nothing is written unless the application asks for it through
+	// Logging.logToDebug or a log sink.
+	webrtc::LoggingConfig loggingConfig;
+	loggingConfig.set_min_severity(webrtc::LS_NONE);
+	loggingConfig.set_debug_severity(webrtc::LS_NONE);
+	webrtc::InitializeLogging(std::move(loggingConfig));
 
 	javaContext = new jni::WebRTCContext(vm);
 

--- a/webrtc/src/test/java/dev/onvoid/webrtc/logging/LoggingTests.java
+++ b/webrtc/src/test/java/dev/onvoid/webrtc/logging/LoggingTests.java
@@ -30,6 +30,15 @@ import org.junit.jupiter.api.Test;
 class LoggingTests {
 
 	@Test
+	void logToDebug() {
+		Logging.logToDebug(Severity.ERROR);
+		Logging.error("logToDebug at ERROR");
+		Logging.logToDebug(Severity.INFO);
+		Logging.logToDebug(Severity.NONE);
+		Logging.info("logToDebug at NONE must not print this");
+	}
+
+	@Test
 	void logInfo() throws Exception {
 		CountDownLatch latch = new CountDownLatch(3);
 


### PR DESCRIPTION
Since the m152 update, libwebrtc initializes its logging configuration on the first log line, with everything from INFO upwards written to stderr, and that configuration can be set only once. Its debug output no longer consults the severity set by `LogMessage::LogToDebug`, so `Logging.logToDebug` had no effect and every application got the full INFO log on stderr, on every platform, which is what #262 reports. The library now initializes the configuration when it is loaded, with the debug output disabled, which restores the previous behavior of staying silent unless asked. `Logging.logToDebug` registers a log sink that writes to the debugger output on Windows and to stderr elsewhere, where libwebrtc wrote before; a sink can be added and removed at any time, so the severity stays adjustable at runtime. The CI test logs show the effect directly: the INFO lines libwebrtc printed on every lane since m152 are gone.

Fixes #262
