### PR TITLE
docs: list the Linux runtime dependencies of the native library

### DIFF
--- a/docs/guide/get-started.md
+++ b/docs/guide/get-started.md
@@ -11,6 +11,18 @@ Maven Central artifacts contain native libraries that can be loaded on the follo
 | macOS     | ✔       | -       | ✔       |
 | Windows   | ✔       | -       | -       |
 
+::: info
+**Linux runtime dependencies**
+
+The Linux native library links the X11 client libraries and the GLib, GBM and libdrm libraries that libwebrtc's desktop capturers use. A minimal installation, for example a container image, needs them installed before the library can load. On Debian and Ubuntu:
+
+```shell
+apt-get install libx11-6 libxext6 libxfixes3 libxdamage1 libxtst6 libxrandr2 libxcomposite1 libglib2.0-0 libgbm1 libdrm2
+```
+
+Since 0.17.0, PulseAudio, udev and D-Bus are opened at runtime only when audio devices, cameras or the screen saver inhibition are used, so the library loads without `libpulse0`, `libudev1` and `libdbus-1-3`. Earlier versions link them and need those three packages as well.
+:::
+
 
 ## Installation
 


### PR DESCRIPTION
The Linux native library fails to load on minimal hosts that lack the X11, GLib, GBM and libdrm libraries libwebrtc's desktop capturers use, which is what #228 and earlier reports ran into. The getting started guide now lists the packages to install on Debian and Ubuntu, and notes that PulseAudio, udev and D-Bus are optional since 0.17.0.
