### PR TITLE
fix: throw instead of aborting when the default audio device module fails to initialize

### DIFF
--- a/webrtc-jni/src/main/cpp/src/JNI_PeerConnectionFactory.cpp
+++ b/webrtc-jni/src/main/cpp/src/JNI_PeerConnectionFactory.cpp
@@ -28,7 +28,9 @@
 #include "JavaRef.h"
 #include "JavaString.h"
 #include "JavaUtils.h"
+#include "WebRTCContext.h"
 
+#include "api/audio/create_audio_device_module.h"
 #include "api/create_peerconnection_factory.h"
 #include "api/audio_codecs/builtin_audio_decoder_factory.h"
 #include "api/audio_codecs/builtin_audio_encoder_factory.h"
@@ -88,6 +90,25 @@ JNIEXPORT void JNICALL Java_dev_onvoid_webrtc_PeerConnectionFactory_initialize
 			: nullptr;
 		webrtc::scoped_refptr<webrtc::AudioProcessing> apm(processing);
 		webrtc::scoped_refptr<webrtc::AudioDeviceModule> adm(audioDevModule);
+
+		if (!adm) {
+			// Without a module, the factory would create the platform default itself
+			// and abort the process when it fails to initialize, which happens on
+			// hosts without an audio system. Create it here instead, the same way
+			// AudioDeviceModule does, so a failure becomes an exception that the
+			// application can handle, for example by passing a module created
+			// with AudioLayer.kDummyAudio.
+			jni::WebRTCContext * context = static_cast<jni::WebRTCContext *>(javaContext);
+
+			adm = webrtc::CreateAudioDeviceModule(context->webrtcEnv, webrtc::AudioDeviceModule::kPlatformDefaultAudio);
+
+			if (!adm) {
+				throw jni::Exception("Create the default AudioDeviceModule failed");
+			}
+			if (adm->Init() != 0) {
+				throw jni::Exception("Initialize the default AudioDeviceModule failed. On a host without an audio system, pass an AudioDeviceModule created with AudioLayer.kDummyAudio.");
+			}
+		}
 
 		auto factory = webrtc::CreatePeerConnectionFactory(
 			networkThread.get(),

--- a/webrtc/src/test/java/dev/onvoid/webrtc/PeerConnectionFactoryTests.java
+++ b/webrtc/src/test/java/dev/onvoid/webrtc/PeerConnectionFactoryTests.java
@@ -30,6 +30,20 @@ import org.junit.jupiter.api.Test;
 class PeerConnectionFactoryTests extends TestBase {
 
 	@Test
+	void createWithoutAudioDeviceModule() {
+		// Without a module the factory creates the platform default. On a host
+		// without an audio system that must fail with an exception, not abort
+		// the process.
+		try {
+			PeerConnectionFactory factory = new PeerConnectionFactory();
+			factory.dispose();
+		}
+		catch (Error e) {
+			assertTrue(e.getMessage().contains("AudioDeviceModule"), e.getMessage());
+		}
+	}
+
+	@Test
 	void createWithAudioDeviceModule() {
 		AudioDeviceModule audioDevModule = new AudioDeviceModule(AudioLayer.kDummyAudio);
 


### PR DESCRIPTION
When no `AudioDeviceModule` is passed, `PeerConnectionFactory` lets libwebrtc create the platform default, and libwebrtc aborts the whole process when that module fails to initialize, which happens on hosts without an audio system such as containers and virtual machines; the second half of #228 is one such crash. The factory now creates the default module itself, the same way `AudioDeviceModule` already does for an explicit module, so the failure surfaces as an exception telling the application to pass a module created with `AudioLayer.kDummyAudio` instead. A test creates the factory without a module and accepts either outcome except a dead process.
