### PR TITLE
build: bootstrap depot_tools before fetching the WebRTC source

### DIFF
--- a/webrtc-jni/src/main/cpp/dependencies/webrtc/CMakeLists.txt
+++ b/webrtc-jni/src/main/cpp/dependencies/webrtc/CMakeLists.txt
@@ -261,6 +261,17 @@ endif()
 
 set(ENV{PATH} "${WEBRTC_SRC_DIR}/depot_tools${PATH_SEP}$ENV{PATH}")
 
+# Since depot_tools d4e95894 the fetch wrapper runs the hermetic Python that
+# only exists after the bootstrap, which fetch used to perform itself. The
+# Windows wrapper still bootstraps on its own.
+if(UNIX)
+    message(STATUS "WebRTC: bootstrap depot tools")
+    execute_command(
+        COMMAND ensure_bootstrap
+        WORKING_DIRECTORY "${WEBRTC_SRC_DIR}/depot_tools"
+    )
+endif()
+
 file(MAKE_DIRECTORY ${WEBRTC_DIR})
 
 message(STATUS "WebRTC: fetch")


### PR DESCRIPTION
depot_tools commit d4e95894 changed the `fetch` wrapper to run the hermetic Python from depot_tools' own `python-bin` directory, which only exists after the bootstrap that `fetch` used to perform itself. A fresh clone followed by `fetch` now fails with "python3_bin_reldir.txt not found", the checkout never happens, and the build fails later on missing objects. Every build without a cached WebRTC library on Linux and macOS has failed this way since 2026-09-08; warm builds still pass, which hides it until the next cold one. Running `ensure_bootstrap` right after the clone restores the previous behavior. The Windows wrapper still bootstraps on its own.
